### PR TITLE
Fix runtime warnings - to main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,8 @@ pytest = "^7.4.4"
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    "ignore::DeprecationWarning:dateutil.tz"
+]

--- a/src/nasem_dairy/NASEM_equations/amino_acid_equations.py
+++ b/src/nasem_dairy/NASEM_equations/amino_acid_equations.py
@@ -75,12 +75,16 @@ def calculate_mPrt_AA_01(AA_mPrtmx: np.array, mPrt_k_AA: np.array,
 
 
 def calculate_mPrt_k_AA(mPrtmx_AA2, mPrt_AA_01, AA_mPrtmx):
-    condition = (mPrtmx_AA2**2 - mPrt_AA_01 * mPrtmx_AA2 <= 0) | (AA_mPrtmx == 0)
-    # Check for sqrt of 0 or divide by 0 errors and set value to 0 if encountered
-    mPrt_k_AA = np.where(
-        condition, 0,
-        -(2 * np.sqrt(mPrtmx_AA2**2 - mPrt_AA_01 * mPrtmx_AA2) - 2 * mPrtmx_AA2)
-        / (AA_mPrtmx * 0.1))
+    mPrt_k_AA = np.zeros_like(mPrtmx_AA2)
+    for i in range(len(mPrtmx_AA2)):
+        inner_value = (
+            mPrtmx_AA2.iloc[i]**2 - mPrt_AA_01.iloc[i] * mPrtmx_AA2.iloc[i]
+            )
+        if inner_value <= 0 or AA_mPrtmx.iloc[i] == 0:
+            mPrt_k_AA[i] = 0
+        else:
+            mPrt_k_AA[i] = (-(2 * np.sqrt(inner_value) - 2 * mPrtmx_AA2.iloc[i]) 
+                            / (AA_mPrtmx.iloc[i] * 0.1))
     return mPrt_k_AA
 
 

--- a/src/nasem_dairy/NASEM_equations/body_composition_equations.py
+++ b/src/nasem_dairy/NASEM_equations/body_composition_equations.py
@@ -573,7 +573,14 @@ def calculate_Body_Gain_NEalow(An_MEavail_Grw: float,
     """
     Body_Gain_NEalow: NE allowable body gain
     """
-    Body_Gain_NEalow = An_MEavail_Grw * Kg_ME_NE / Body_NEgain_BWgain # Line 2950
+    if (Body_NEgain_BWgain != 0 # Line 2950
+        and not np.isnan(An_MEavail_Grw) 
+        and not np.isnan(Kg_ME_NE) 
+        and not np.isnan(Body_NEgain_BWgain)
+        ):
+        Body_Gain_NEalow = An_MEavail_Grw * Kg_ME_NE / Body_NEgain_BWgain 
+    else:
+        Body_Gain_NEalow = np.nan
     return Body_Gain_NEalow
 
 

--- a/src/nasem_dairy/NASEM_equations/manure_equations.py
+++ b/src/nasem_dairy/NASEM_equations/manure_equations.py
@@ -1,6 +1,8 @@
 # Manure equations
 # import nasem_dairy.NASEM_equations.manure_equations as manure
 
+import numpy as np
+
 def calculate_Man_out(An_StatePhys: str, An_DMIn: float, Dt_K: float) -> float:
     """
     Man_out: kg wet manure production
@@ -86,7 +88,10 @@ def calculate_ManN_Milk(Man_Nout_g: float, Mlk_Prod: float) -> float:
     """
     ManN_Milk: g manure N / kg milk production (g/kg)
     """
-    ManN_Milk = Man_Nout_g / Mlk_Prod  # g N / kg of milk, Line 3259
+    if Mlk_Prod != 0 and not np.isnan(Mlk_Prod):
+        ManN_Milk = Man_Nout_g / Mlk_Prod # g N / kg of milk, Line 3259
+    else:
+        ManN_Milk = None
     return ManN_Milk
 
 
@@ -235,5 +240,8 @@ def calculate_ManWa_Milk(Man_Wa_out: float, Mlk_Prod: float) -> float:
 
 
 def calculate_VolSlds2_Milk(Man_VolSld2: float, Mlk_Prod: float) -> float:
-    VolSlds2_Milk = Man_VolSld2 / Mlk_Prod  # kg/kg; mass balance derived
+    if Mlk_Prod != 0 and not np.isnan(Mlk_Prod):
+        VolSlds2_Milk = Man_VolSld2 / Mlk_Prod # kg/kg; mass balance derived
+    else:
+        VolSlds2_Milk = np.nan 
     return VolSlds2_Milk

--- a/src/nasem_dairy/NASEM_equations/micronutrient_requirement_equations.py
+++ b/src/nasem_dairy/NASEM_equations/micronutrient_requirement_equations.py
@@ -3,6 +3,7 @@
 
 import math
 
+import numpy as np
 
 ### CALCIUM ###
 def calculate_Ca_Mlk(An_Breed: str) -> float:
@@ -1170,7 +1171,10 @@ def calculate_Dt_acCo(Abs_CoIn: float, Dt_CoIn: float) -> float:
     """
     Dt_acCo: Diet level absorption coefficient cobalt (g/g)
     """
-    Dt_acCo = Abs_CoIn / Dt_CoIn  # Line 3230
+    if Dt_CoIn != 0 and not np.isnan(Abs_CoIn) and not np.isnan(Dt_CoIn):
+        Dt_acCo = Abs_CoIn / Dt_CoIn # Line 3230
+    else:
+        Dt_acCo = None
     return Dt_acCo
 
 

--- a/src/nasem_dairy/NASEM_equations/milk_equations.py
+++ b/src/nasem_dairy/NASEM_equations/milk_equations.py
@@ -282,7 +282,10 @@ def calculate_Mlk_Prod_MPalow(Mlk_NP_MPalow_Trg_g: float,
     """
     Mlk_Prod_MPalow: Metabolizable protein allowable milk production, kg/d
     """
-    Mlk_Prod_MPalow = Mlk_NP_MPalow_Trg_g / (Trg_MilkTPp / 100) / 1000
+    if Trg_MilkTPp != 0:
+        Mlk_Prod_MPalow = Mlk_NP_MPalow_Trg_g / (Trg_MilkTPp / 100) / 1000
+    else:
+        Mlk_Prod_MPalow = None
     # Line 2708, kg milk/d using Trg milk protein % to predict volume
     return Mlk_Prod_MPalow
 
@@ -308,8 +311,11 @@ def calculate_Mlk_Prod_NEalow(An_MEavail_Milk: float,
     """
     req_coeff = ['Kl_ME_NE']
     ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    if Trg_NEmilk_Milk != 0 and not np.isnan(Trg_NEmilk_Milk):
+        Mlk_Prod_NEalow = An_MEavail_Milk * coeff_dict['Kl_ME_NE'] / Trg_NEmilk_Milk
+    else:
+        Mlk_Prod_NEalow = np.nan 
     # Line 2898, Energy allowable Milk Production, kg/d
-    Mlk_Prod_NEalow = An_MEavail_Milk * coeff_dict['Kl_ME_NE'] / Trg_NEmilk_Milk
     return Mlk_Prod_NEalow
 
 
@@ -562,10 +568,16 @@ def calculate_Mlk_Prod_NEalow_EPcor(Mlk_Prod_NEalow: float,
     """
     Mlk_Prod_NEalow_EPcor: NE allowable energy and protein corrected milk production (kg/d)
     """
-    Mlk_Prod_NEalow_EPcor = 0.327 * Mlk_Prod_NEalow + (
-        12.97 * Trg_MilkFatp / 100 * Mlk_Prod_NEalow) + (
-            7.65 * Trg_MilkTPp / 100 * Mlk_Prod_NEalow
-        )  # energy and protein corrected milk, Line 2901-2902
+    if (np.isnan(Mlk_Prod_NEalow) or np.isnan(Trg_MilkFatp) or 
+        np.isnan(Trg_MilkTPp) or Mlk_Prod_NEalow <= 0 or 
+        Trg_MilkFatp <= 0 or Trg_MilkTPp <= 0
+        ):
+        Mlk_Prod_NEalow_EPcor = np.nan
+    else:
+        Mlk_Prod_NEalow_EPcor = 0.327 * Mlk_Prod_NEalow + (
+            12.97 * Trg_MilkFatp / 100 * Mlk_Prod_NEalow) + (
+                7.65 * Trg_MilkTPp / 100 * Mlk_Prod_NEalow
+            )  # energy and protein corrected milk, Line 2901-2902
     return Mlk_Prod_NEalow_EPcor
 
 

--- a/src/nasem_dairy/NASEM_equations/nutrient_intakes.py
+++ b/src/nasem_dairy/NASEM_equations/nutrient_intakes.py
@@ -848,7 +848,10 @@ def calculate_Dt_ForDNDF48(Fd_DMInp, Fd_Conc, Fd_NDF, Fd_DNDF48):
 
 
 def calculate_Dt_ForDNDF48_ForNDF(Dt_ForDNDF48, Dt_ForNDF):
-    Dt_ForDNDF48_ForNDF = Dt_ForDNDF48 / Dt_ForNDF * 100  # Line 260
+    if Dt_ForNDF != 0 and not np.isnan(Dt_ForNDF):
+        Dt_ForDNDF48_ForNDF = Dt_ForDNDF48 / Dt_ForNDF * 100 # Line 260
+    else:
+        Dt_ForDNDF48_ForNDF = None
     return Dt_ForDNDF48_ForNDF
 
 

--- a/tests/nasem_unit_testing/amino_acid_test.json
+++ b/tests/nasem_unit_testing/amino_acid_test.json
@@ -61,17 +61,17 @@
     },
     {
       "Name": "calculate_mPrt_k_AA",
-      "Input": {"mPrtmx_AA2": 15, "mPrt_AA_01": 50, "AA_mPrtmx": 5},
-      "Output": 0
+      "Input": {"mPrtmx_AA2": [15], "mPrt_AA_01": [50], "AA_mPrtmx": [5]},
+      "Output": [0]
     },
     {
       "Name": "calculate_mPrt_k_AA",
-      "Input": {"mPrtmx_AA2": 10, "mPrt_AA_01": 10, "AA_mPrtmx": 0},
-      "Output": 0
+      "Input": {"mPrtmx_AA2": [10], "mPrt_AA_01": [10], "AA_mPrtmx": [0]},
+      "Output": [0]
     },
     {
       "Name": "calculate_mPrt_k_AA",
-      "Input": {"mPrtmx_AA2": 1, "mPrt_AA_01": 0.5, "AA_mPrtmx": 0.1},
-      "Output": 58.57864376
+      "Input": {"mPrtmx_AA2": [1], "mPrt_AA_01": [0.5], "AA_mPrtmx": [0.1]},
+      "Output": [58.57864376]
     }
   ]


### PR DESCRIPTION
Initial PR (#110) was deleted as it was merging onto `repeated_test_code` instead of `main` and was therefore deleted after merging `repeated_test_code`. 
Rebased main onto this branch and all tests passing with no warnings.



### Description of changes
Refactor functions to prevent RuntimeWarning when testing
Ignore deprecation warning from dateutil.tz. This seems to be caused by one of the packages we are using

### Issue number/s 
fixes #41

### Checklist of all completed
Mark with `[x]` to show completed:  

- [x] No merge conflicts (if conflicts, merge main to branch and resolve before making PR)
- [x] Tests written (if feature added or refactored)
- [x] pytest passing
- [ ] Docstrings - minor
- [ ] Full documentation