### PR TITLE
Refactor_np_where

### DIFF
--- a/src/nasem_dairy/NASEM_equations/animal_equations.py
+++ b/src/nasem_dairy/NASEM_equations/animal_equations.py
@@ -219,10 +219,10 @@ def calculate_An_DEIn(An_StatePhys, An_DENDFIn, An_DEStIn, An_DErOMIn,
                       Monensin_eqn):
     An_DEIn = (An_DENDFIn + An_DEStIn + An_DErOMIn + An_DETPIn + An_DENPNCPIn +
                An_DEFAIn + Inf_DEAcetIn + Inf_DEPropIn + Inf_DEButrIn)
-    condition = (An_StatePhys == "Calf") and (Dt_DMIn_ClfLiq > 0)
     # Infusion DE not considered for milk-fed calves
-    An_DEIn = np.where(condition, Dt_DEIn, An_DEIn)
-    An_DEIn = np.where(Monensin_eqn == 1, An_DEIn * 1.02, An_DEIn)
+    condition = (An_StatePhys == "Calf") and (Dt_DMIn_ClfLiq > 0)   
+    An_DEIn = Dt_DEIn if condition else An_DEIn     
+    An_DEIn = An_DEIn * 1.02 if Monensin_eqn == 1 else An_DEIn
     return An_DEIn
 
 
@@ -323,15 +323,12 @@ def calculate_An_MEIn(An_StatePhys, An_BW, An_DEIn, An_GasEOut, Ur_DEout,
     condition = ((An_StatePhys == "Calf") 
                  and (Dt_DMIn_CflLiq > 0.015 * An_BW) 
                  and (RumDevDisc_Clf > 0))
-    K_DE_ME_ClfDry = np.where(condition, 0.93 * 0.9, 0.93) # Line 2755
-    An_MEIn = An_DEIn - An_GasEOut - Ur_DEout  # Line 2753
+    K_DE_ME_ClfDry = 0.93 * 0.9 if condition else 0.93 # Line 2755   
     
-    condition2 = (An_StatePhys == "Calf") and (Dt_DMIn_CflLiq > 0)
-    An_MEIn = np.where(
-        condition2,
-        Dt_DEIn_base_ClfLiq * 0.96 + Dt_DEIn_base_ClfDry * K_DE_ME_ClfDry,  
-        # Line 2757, no consideration of infusions for calves.
-        An_MEIn)
+    An_MEIn = An_DEIn - An_GasEOut - Ur_DEout  # Line 2753
+    An_MEIn = (Dt_DEIn_base_ClfLiq * 0.96 + Dt_DEIn_base_ClfDry * K_DE_ME_ClfDry
+               if (An_StatePhys == "Calf") and (Dt_DMIn_CflLiq > 0) 
+               else An_MEIn) 
     return An_MEIn
 
 

--- a/src/nasem_dairy/NASEM_equations/energy_requirement_equations.py
+++ b/src/nasem_dairy/NASEM_equations/energy_requirement_equations.py
@@ -772,7 +772,7 @@ def calculate_Gest_MEuse(Gest_REgain: float) -> float:
     nd.calculate_Gest_MEuse(Gest_REgain)
     ```
     """
-    Ky_ME_NE = np.where(Gest_REgain >= 0, 0.14, 0.89)
+    Ky_ME_NE = 0.14 if Gest_REgain >= 0 else 0.89
     # Gain from Ferrell et al, 1976, and loss assumed = Rsrv loss, Line 2860
     Gest_MEuse = Gest_REgain / Ky_ME_NE
     return Gest_MEuse

--- a/src/nasem_dairy/NASEM_equations/fecal_equations.py
+++ b/src/nasem_dairy/NASEM_equations/fecal_equations.py
@@ -44,8 +44,7 @@ def calculate_Fe_CPend_g(An_StatePhys: str,
         # Originally K_FeCPend_ClfLiq is set to 11.9 in book; but can be either 11.9 or 34.4
         # (An_DMIn - Dt_DMIn_ClfLiq) represents solid feed DM intake
         # should only be called if calf:
-        K_FeCPend_ClfLiq = np.where(NonMilkCP_ClfLiq > 0, 34.4, 11.9)
-
+        K_FeCPend_ClfLiq = 34.4 if NonMilkCP_ClfLiq > 0 else 11.9
         Fe_CPend_g = (K_FeCPend_ClfLiq * Dt_DMIn_ClfLiq + 
                       20.6 * (An_DMIn - Dt_DMIn_ClfLiq))
     else:
@@ -75,12 +74,10 @@ def calculate_Fe_CP(An_StatePhys,
     # Line 1202, Double counting portion of RumMiCP derived from End CP. Needs to be fixed. MDH
     Fe_CP = (Fe_RUP + Fe_RumMiCP + Fe_CPend + 
              InfSI_NPNCPIn * (1 - coeff_dict['dcNPNCP'] / 100))
-    Fe_CP = np.where(
-        An_StatePhys == "Calf",
-        (1 - coeff_dict['Dt_dcCP_ClfLiq']) * Dt_CPIn_ClfLiq +
-        (1 - Dt_dcCP_ClfDry) * (An_CPIn - Dt_CPIn_ClfLiq) + Fe_CPend, 
-        Fe_CP
-    ) # CP based for calves. Ignores RDP, RUP, Fe_NPend, etc.  Needs refinement.
+    # CP based for calves. Ignores RDP, RUP, Fe_NPend, etc.  Needs refinement.
+    if An_StatePhys == "Calf": 
+        Fe_CP = ((1 - coeff_dict['Dt_dcCP_ClfLiq']) * Dt_CPIn_ClfLiq 
+                 + (1 - Dt_dcCP_ClfDry) * (An_CPIn - Dt_CPIn_ClfLiq) + Fe_CPend)    
     return Fe_CP
 
 

--- a/src/nasem_dairy/NASEM_equations/protein_requirement_equations.py
+++ b/src/nasem_dairy/NASEM_equations/protein_requirement_equations.py
@@ -142,31 +142,27 @@ def calculate_Kg_MP_NP_Trg(An_StatePhys: str,
     """
     req_coeff = ['Body_NP_CP']
     ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
-    Kg_MP_NP_Trg = 0.60 * coeff_dict['Body_NP_CP']  
     # Default value for Growth MP to TP.  Shouldn't be used for any., Line 2659
-    condition = (An_Parity_rl == 0) and (An_BW_empty / An_BWmature_empty > 0.12)
-    Kg_MP_NP_Trg = np.where(
-        condition,  # Line 2660-2662
-        (0.64 - 0.3 * An_BW_empty / An_BWmature_empty) *
-        coeff_dict['Body_NP_CP'],  # for heifers from 12% until 83% of BW_mature
-        Kg_MP_NP_Trg)
-    
-    Kg_MP_NP_Trg = np.where(
-        Kg_MP_NP_Trg < 0.394 * coeff_dict['Body_NP_CP'],
-        0.394 * coeff_dict['Body_NP_CP'] * coeff_dict['Body_NP_CP'],  
+    Kg_MP_NP_Trg = 0.60 * coeff_dict['Body_NP_CP']  
+
+    if (An_Parity_rl == 0) and (An_BW_empty / An_BWmature_empty > 0.12):
+        # for heifers from 12% until 83% of BW_mature
+        Kg_MP_NP_Trg = ((0.64 - 0.3 * An_BW_empty / An_BWmature_empty) 
+                        * coeff_dict['Body_NP_CP'])
+        
+    if Kg_MP_NP_Trg < 0.394 * coeff_dict['Body_NP_CP']:
         # Trap heifer values less than 0.39 MP to CP, Line 2663
-        Kg_MP_NP_Trg)
+        Kg_MP_NP_Trg = (0.394 * coeff_dict['Body_NP_CP'] 
+                        * coeff_dict['Body_NP_CP'])
     
-    Kg_MP_NP_Trg = np.where(
-        An_StatePhys == "Calf",
-        (0.70 - 0.532 * (An_BW / An_BW_mature)) * coeff_dict['Body_NP_CP'],  
+    if An_StatePhys == "Calf":
         # calves, Line 2664
-        Kg_MP_NP_Trg)
-    
-    Kg_MP_NP_Trg = np.where(
-        An_Parity_rl > 0,
-        MP_NP_efficiency_dict['Trg_MP_NP'],  # Cows, Line 2665
-        Kg_MP_NP_Trg)
+        Kg_MP_NP_Trg = ((0.70 - 0.532 * (An_BW / An_BW_mature)) 
+                        * coeff_dict['Body_NP_CP'])
+        
+    if An_Parity_rl > 0:
+        # Cows, Line 2665
+        Kg_MP_NP_Trg = MP_NP_efficiency_dict['Trg_MP_NP']
     return Kg_MP_NP_Trg
 
 

--- a/src/nasem_dairy/ration_balancer/ModelOutput.py
+++ b/src/nasem_dairy/ration_balancer/ModelOutput.py
@@ -172,10 +172,10 @@ class ModelOutput:
             # Check if the value is numeric
             if isinstance(raw_value, (float, int)):
                 value = round(raw_value, 3)
-            elif isinstance(raw_value, (np.ndarray)) and raw_value.size == 1:
-                # This is required for any numbers handled by np.where() that 
-                # return arrays instead of floats - needs cleaning up
-                value = round(float(raw_value), 3)
+            # elif isinstance(raw_value, (np.ndarray)) and raw_value.size == 1:
+            #     # This is required for any numbers handled by np.where() that 
+            #     # return arrays instead of floats - needs cleaning up
+            #     value = round(float(raw_value), 3)
             else:
                 value = raw_value
 


### PR DESCRIPTION
Comment out check for arrays

_Fill in information for PR below. On review, add additional commits and a comment thats checks off any tasks so that all are complete before merging._

### Description of changes
Refactor use of np.where outside of nutrient_intakes module to prevent converting type to array.  np.where is used in nutrient_intakes module as this is correct methodd for handling boolean logic. These function returns are assigned to Dataframe columns which will covert them to pandas Series anyway. 

### Issue number/s 
fixes #107

### Checklist of all completed
Mark with `[x]` to show completed:  

- [x] No merge conflicts (if conflicts, merge main to branch and resolve before making PR)
- [x] Tests written (if feature added or refactored)
- [x] pytest passing
- [x] Docstrings - minor
- [ ] Full documentation