### PR TITLE
Remove check coeffs in coeff dict

### DIFF
--- a/src/nasem_dairy/__init__.py
+++ b/src/nasem_dairy/__init__.py
@@ -2,7 +2,7 @@
 from importlib.metadata import version
 __version__ = version("nasem_dairy")
 
-from nasem_dairy.model.utilities import get_feed_rows_feedlibrary, check_coeffs_in_coeff_dict, read_csv_input, read_infusion_input
+from nasem_dairy.model.utilities import get_feed_rows_feedlibrary, read_csv_input, read_infusion_input
 from nasem_dairy.model_output.ModelOutput import ModelOutput
 from nasem_dairy.model.execute_model import execute_model
 from nasem_dairy.data.constants import coeff_dict, infusion_dict, MP_NP_efficiency_dict, mPrt_coeff_list, f_Imb

--- a/src/nasem_dairy/model/utilities.py
+++ b/src/nasem_dairy/model/utilities.py
@@ -5,58 +5,6 @@ from typing import Dict, Tuple, Union
 import pandas as pd
 
 
-def check_coeffs_in_coeff_dict(input_coeff_dict: dict, 
-                               required_coeffs: list
-) -> None:
-    '''
-    Internal function that is used by other functions that require certain model coefficients from a coefficient dictionary. Typically this 
-    will be the built-in dictionary in [](`~nasem_dairy.ration_balancer.constants`). 
-    This function will check if the required coeffs are in the dictionary provided to the function, and if not it will return a useful error.
-
-    Parameters
-    ----------
-    input_coeff_dict : dict
-        Coefficient dictionary, normally called as `coeff_dict` by functions
-    required_coeffs : list
-        A list of strings that contain the names of the required coefficients to check for in the dictionary.
-
-    Returns
-    -------
-    None
-
-    Examples
-    --------
-    Filter the NASEM feed library for specific feeds:
-    
-    ```{python}
-    import nasem_dairy as nd
-
-    req_coeffs = ['En_CP', 'En_FA', 'En_rOM', 'En_St', 'En_NDF']
-
-    nd.check_coeffs_in_coeff_dict(
-        input_coeff_dict = nd.coeff_dict, 
-        required_coeffs = req_coeffs)
-
-    ```
-
-    '''
-    # Convert the list to a set for faster lookup
-    req_coef = set(required_coeffs)
-    dict_in = set(input_coeff_dict)
-
-    # Return coeffs that are not in dict_in
-    missing_coeffs = [value for value in req_coef if value not in dict_in]
-
-    # Check if all values are present in the dictionary
-    result = not bool(missing_coeffs)
-
-    # Raise an AssertionError with a custom message containing missing values 
-    # if the condition is False
-    assert result, f"Missing values in coeff_dict: {missing_coeffs}"
-
-    return
-
-
 def get_feed_rows_feedlibrary(feeds_to_get: list,
                               feed_lib_df: pd.DataFrame
 ) -> pd.DataFrame:

--- a/src/nasem_dairy/nasem_equations/amino_acid.py
+++ b/src/nasem_dairy/nasem_equations/amino_acid.py
@@ -6,7 +6,6 @@ import math
 import numpy as np
 import pandas as pd
 
-import nasem_dairy.model.utilities as ration_funcs
 
 def calculate_MiTPAAProf(AA_list: list, coeff_dict: dict) -> np.ndarray:
     """

--- a/src/nasem_dairy/nasem_equations/amino_acid.py
+++ b/src/nasem_dairy/nasem_equations/amino_acid.py
@@ -9,12 +9,25 @@ import pandas as pd
 import nasem_dairy.model.utilities as ration_funcs
 
 def calculate_MiTPAAProf(AA_list: list, coeff_dict: dict) -> np.ndarray:
-    req_coeffs = [
-        'MiTPArgProf', 'MiTPHisProf', 'MiTPIleProf', 'MiTPLeuProf',
-        'MiTPLysProf', 'MiTPMetProf', 'MiTPPheProf', 'MiTPThrProf',
-        'MiTPTrpProf', 'MiTPValProf'
-    ]
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeffs)
+    """
+    Examples
+    --------
+
+    ```
+    coeff_dict = {
+        "MiTPArgProf": 5.47, "MiTPHisProf": 2.21, "MiTPIleProf": 6.99, 
+        "MiTPLeuProf": 9.23, "MiTPLysProf": 9.44, "MiTPMetProf": 2.63, 
+        "MiTPPheProf": 6.30, "MiTPThrProf": 6.23, "MiTPTrpProf": 1.37, 
+        "MiTPValProf": 6.88
+    }
+    
+    calculate_MiTPAAProf(
+        AA_list = ["Arg", "His", "Ile", "Leu", "Lys", 
+                   "Met", "Phe", "Thr", "Trp", "Val"]
+        coeff_dict = coeff_dict
+    )
+    ```
+    """
     MiTPAAProf = np.array([coeff_dict[f"MiTP{AA}Prof"] for AA in AA_list])
     return MiTPAAProf
 
@@ -25,8 +38,21 @@ def calculate_Du_AAMic(Du_MiTP_g: float, MiTPAAProf: np.ndarray) -> np.ndarray:
 
 
 def calculate_Du_IdAAMic(Du_AAMic: float, coeff_dict: dict) -> float:
-    req_coeffs = ['SI_dcMiCP']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeffs)
+    """
+    Examples
+    --------
+
+    ```
+    coeff_dict = {
+        "SI_dcMiCP": 80
+    }
+    
+    calculate_MiTPAAProf(
+        Du_AAMic = 12.8,
+        coeff_dict = coeff_dict
+    )
+    ```
+    """
     Du_IdAAMic = Du_AAMic * coeff_dict['SI_dcMiCP'] / 100
     return Du_IdAAMic
 
@@ -184,11 +210,25 @@ def calculate_mPrt_k_EAA2(mPrtmx_Met2: float,
 
 
 def calculate_EndAAProf(AA_list: list, coeff_dict: dict) -> np.ndarray:
-    req_coeffs = [
-        'EndArgProf', 'EndHisProf', 'EndIleProf', 'EndLeuProf', 'EndLysProf',
-        'EndMetProf', 'EndPheProf', 'EndThrProf', 'EndTrpProf', 'EndValProf'
-    ]
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeffs)
+    """
+    Examples
+    --------
+
+    ```
+    coeff_dict = {
+        "EndArgProf":" 4.61, "EndHisProf":" 2.90, "EndIleProf":" 4.09, 
+        "EndLeuProf":" 7.67, "EndLysProf":" 6.23"EndMetProf":" 1.26, 
+        "EndPheProf":" 3.98, "EndThrProf":" 5.18, "EndTrpProf":" 1.29, 
+        "EndValProf":" 5.29
+    }
+    
+    calculate_EndAAProf(
+        AA_list = ["Arg", "His", "Ile", "Leu", "Lys", 
+                   "Met", "Phe", "Thr", "Trp", "Val"],
+        coeff_dict = coeff_dict
+    )
+    ```
+    """
     EndAAProf = np.array([coeff_dict[f"End{AA}Prof"] for AA in AA_list])
     return EndAAProf
 
@@ -551,9 +591,21 @@ def calculate_Trg_AbsAA_g(Trg_Mlk_AA_g: pd.Series,
 ) -> pd.Series:
     """
     Trg_AbsAA_g: Absorbed AA at user entered production (g/d)
+
+    Examples
+    --------
+
+    ```
+    coeff_dict = {"Ky_MP_NP_Trg": 0.33}
+
+    calculate_Trg_AbsAA_g(
+        Trg_Mlk_AA_g = pd.Series([10, 20, 30]), Scrf_AA_g = pd.Series([1, 2, 3]),
+        Fe_AAMet_g = pd.Series([5, 10, 15]), Trg_AbsAA_NPxprtAA = pd.Series([0.5, 1.0, 1.5])
+        Ur_AAEnd_g = pd.Series([2, 4, 6]), Gest_AA_g = pd.Series([3, 6, 9]),
+        Body_AAGain_g = pd.Series([7, 14, 21]), Kg_MP_NP_Trg = 0.33, coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['Ky_MP_NP_Trg']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     Trg_AbsAA_g = ((Trg_Mlk_AA_g + Scrf_AA_g + Fe_AAMet_g) / 
                    Trg_AbsAA_NPxprtAA + Ur_AAEnd_g + Gest_AA_g / 
                    coeff_dict['Ky_MP_NP_Trg'] + Body_AAGain_g / Kg_MP_NP_Trg)  
@@ -591,12 +643,23 @@ def calculate_AnNPxAA_AbsAA(An_AAUse_g: pd.Series,
 ) -> pd.Series:
     """
     AnNPxAA_AbsAA: Predicted Efficiency of AbsAA to export and gain NPAA using Nutrient Allowable milk protein, g NPAA/g absorbed AA
+
+    Examples
+    --------
+
+    ```
+    coeff_dict = {"Ky_MP_NP_Trg": 0.33}
+    
+    calculate_EndAAProf(
+        An_AAUse_g = pd.Series([50, 100, 150]), Gest_AA_g = pd.Series([10, 20, 30]),
+        Ur_AAEnd_g = pd.Series([5, 10, 15]), Abs_AA_g = pd.Series([60, 120, 180]),
+        coeff_dict = coeff_dict
+    )
+    ```
     """
     # Predicted Efficiency of AbsAA to export and gain NPAA using Nutrient Allowable
     # milk protein, g NPAA/g absorbed AA (Ur_AAend use set to an efficiency of 1).
     # These are for comparison to Trg AA Eff.
-    req_coeff = ['Ky_MP_NP_Trg']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     AnNPxAA_AbsAA = (An_AAUse_g - Gest_AA_g - Ur_AAEnd_g) / (
         Abs_AA_g - Ur_AAEnd_g - Gest_AA_g / coeff_dict['Ky_MP_NP_Trg']
     )  # Subtract Gest_AA and UrEnd for use and supply, Line 3197-3206
@@ -611,9 +674,19 @@ def calculate_AnNPxEAA_AbsEAA(An_EAAUse_g: float,
 ) -> float:
     """
     AnNPxEAA_AbsEAA: Predicted Efficiency of AbsEAA to export and gain NPEAA using Nutrient Allowable milk protein, g NPEAA/g absorbed EAA
+       
+    Examples
+    --------
+
+    ```
+    coeff_dict = {"Ky_MP_NP_Trg": 0.33}
+    
+    calculate_AnNPxEAA_AbsEAA(
+        An_EAAUse_g = 150.0, Gest_EAA_g = 30.0, Ur_EAAEnd_g = 15.0, 
+        Abs_EAA_g = 180.0, coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['Ky_MP_NP_Trg']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     AnNPxEAA_AbsEAA = (An_EAAUse_g - Gest_EAA_g - Ur_EAAEnd_g) / (
         Abs_EAA_g - Ur_EAAEnd_g - Gest_EAA_g / coeff_dict['Ky_MP_NP_Trg']
     )  # Line 3207
@@ -628,11 +701,22 @@ def calculate_AnNPxAAUser_AbsAA(Trg_AAUse_g: pd.Series,
 ) -> pd.Series:
     """
     AnNPxAAUser_AbsAA: Efficiency of AbsAA to export and gain NPAA at User Entered milk protein, g NPAA/g absorbed AA
+    
+    Examples
+    --------
+
+    ```
+    coeff_dict = {"Ky_MP_NP_Trg": 0.33}
+    
+    calculate_AnNPxAAUser_AbsAA(
+        Trg_AAUse_g = pd.Series([50, 100, 150]), Gest_AA_g = pd.Series([10, 20, 30]), 
+        Ur_AAEnd_g = pd.Series([5, 10, 15]), Abs_AA_g = pd.Series([60, 120, 180]),
+        coeff_dict = coeff_dict
+    )
+    ```
     """
     # Efficiency of AbsAA to export and gain NPAA at User Entered milk protein, 
     # g NPAA/g absorbed AA (Ur_AAend use set to an efficiency of 1).
-    req_coeff = ['Ky_MP_NP_Trg']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     AnNPxAAUser_AbsAA = (Trg_AAUse_g - Gest_AA_g - Ur_AAEnd_g) / (
         Abs_AA_g - Ur_AAEnd_g - Gest_AA_g / coeff_dict['Ky_MP_NP_Trg']
     )  # Subtract Gest_AA and UrEnd for use and supply, Line 3210-3219

--- a/src/nasem_dairy/nasem_equations/animal.py
+++ b/src/nasem_dairy/nasem_equations/animal.py
@@ -3,7 +3,6 @@
 import numpy as np
 import pandas as pd
 
-import nasem_dairy.model.utilities as ration_funcs
 
 ####################
 # Functions for Animal Level Intakes in Wrappers

--- a/src/nasem_dairy/nasem_equations/animal.py
+++ b/src/nasem_dairy/nasem_equations/animal.py
@@ -45,8 +45,17 @@ def calculate_An_DigNDFIn(Dt_DigNDFIn: float,
 
 
 def calculate_An_DENDFIn(An_DigNDFIn: float, coeff_dict: dict) -> float:
-    req_coeff = ['En_NDF']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {"En_NDF": 0.45}
+    
+    calculate_An_DENDFIn(
+        An_DigNDFIn = 200.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     An_DENDFIn = An_DigNDFIn * coeff_dict['En_NDF']  # Line 1353
     return An_DENDFIn
 
@@ -61,8 +70,17 @@ def calculate_An_DigStIn(Dt_DigStIn: float,
 
 
 def calculate_An_DEStIn(An_DigStIn: float, coeff_dict: dict) -> float:
-    req_coeff = ['En_St']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {"En_St": 4.23}
+    
+    calculate_An_DEStIn(
+        An_DigStIn = 250.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     An_DEStIn = An_DigStIn * coeff_dict['En_St']  # Line 1351
     return An_DEStIn
 
@@ -84,8 +102,17 @@ def calculate_An_DigrOMaIn(Dt_DigrOMaIn: float,
 
 
 def calculate_An_DErOMIn(An_DigrOMaIn: float, coeff_dict: dict) -> float:
-    req_coeff = ['En_rOM']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {"En_rOM": 4.0}
+    
+    calculate_An_DErOMIn(
+        An_DigrOMaIn = 300.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     An_DErOMIn = An_DigrOMaIn * coeff_dict['En_rOM']  # Line 1351
     return An_DErOMIn
 
@@ -186,15 +213,33 @@ def calculate_An_DigCPaIn(An_CPIn: float,
 
 
 def calculate_An_DECPIn(An_DigCPaIn: float, coeff_dict: dict) -> float:
-    req_coeff = ['En_CP']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {"En_CP": 5.65}
+    
+    calculate_An_DECPIn(
+        An_DigCPaIn = 100.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     An_DECPIn = An_DigCPaIn * coeff_dict['En_CP']
     return An_DECPIn
 
 
 def calculate_An_DENPNCPIn(Dt_NPNCPIn: float, coeff_dict: dict) -> float:
-    req_coeff = ['dcNPNCP', 'En_NPNCP']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {"dcNPNCP": 100, "En_NPNCP": 0.89}
+    
+    calculate_An_DENPNCPIn(
+        Dt_NPNCPIn = 50.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     An_DENPNCPIn = (Dt_NPNCPIn * coeff_dict['dcNPNCP'] / 
                     100 * coeff_dict['En_NPNCP'])
     return An_DENPNCPIn
@@ -204,8 +249,17 @@ def calculate_An_DETPIn(An_DECPIn: float,
                         An_DENPNCPIn: float, 
                         coeff_dict: dict
 ) -> float:
-    req_coeff = ['En_NPNCP', 'En_CP']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {"En_NPNCP": 0.89, "En_CP": 5.65}
+    
+    calculate_An_DETPIn(
+        An_DECPIn = 100.0, An_DENPNCPIn = 40.0, coeff_dict = coeff_dict
+    )
+    ```
+    """    
     # Line 1355, Caution! DigTPaIn not clean so subtracted DE for CP equiv of
     # NPN to correct. Not a true DE_TP.
     An_DETPIn = (An_DECPIn - An_DENPNCPIn / 
@@ -219,8 +273,17 @@ def calculate_An_DigFAIn(Dt_DigFAIn: float, Inf_DigFAIn: float) -> float:
 
 
 def calculate_An_DEFAIn(An_DigFAIn: float, coeff_dict: dict) -> float:
-    req_coeff = ['En_FA']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {"En_FA": 9.4}
+    
+    calculate_An_DEFAIn(
+        An_DigFAIn = 150.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     An_DEFAIn = An_DigFAIn * coeff_dict['En_FA']  # Line 1361
     return An_DEFAIn
 
@@ -268,10 +331,21 @@ def calculate_An_GutFill_BW(An_BW: float,
     """
     see page 34 for comments, gut fill is default 0.18 for cows
     Weaned calf == heifer, which is based on equations 11-1a/b using 85% (inverse of 0.15)
-    Comments in book suggest this is not always a suitable assumption (that gut fill is 15% of BW), consider making this a coeff that can be changed in coeff_dict?
+    Comments in book suggest this is not always a suitable assumption (that gut fill is 15% of BW), 
+    consider making this a coeff that can be changed in coeff_dict?
+    
+    Examples
+    --------
+    ```
+    coeff_dict = {"An_GutFill_BWmature": 0.18}
+    
+    calculate_An_GutFill_BW(
+        An_BW = 500.0, An_BW_mature = 600.0, An_StatePhys = "Lactating Cow", 
+        An_Parity_rl = 2, Dt_DMIn_ClfLiq = 0.0, Dt_DMIn_ClfStrt = 0.0, 
+        coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['An_GutFill_BWmature']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     An_GutFill_BW = 0.06  # Line 2402, Milk fed calf, kg/kg BW
     if (
         (An_StatePhys == "Calf") 
@@ -767,9 +841,18 @@ def calculate_An_RDTPIn(Dt_RDTPIn: float,
 ) -> float:
     """
     An_RDTPIn: Rumen degradable true protein intake, kg/d
+    
+    Examples
+    --------
+    ```
+    coeff_dict = {"dcNPNCP": 100}
+    
+    calculate_An_RDTPIn(
+        Dt_RDTPIn = 200.0, InfRum_RDPIn = 150.0, InfRum_NPNCPIn = 30.0, 
+        coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['dcNPNCP']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     An_RDTPIn = (Dt_RDTPIn + 
                  (InfRum_RDPIn - InfRum_NPNCPIn * coeff_dict['dcNPNCP'] / 100))  
     # Line 1107
@@ -1065,12 +1148,22 @@ def calculate_An_GEIn(Dt_GEIn: float,
 ) -> float:
     """
     An_GEIn: Gross energy intake (Mcal/d)
+
+    Examples
+    --------
+    ```
+    coeff_dict = {
+        "En_NDF": 0.45, "En_St": 0.50, "En_FA": 0.85, "En_CP": 0.75, 
+        "En_NPNCP": 0.55, "En_Acet": 0.90, "En_Prop": 1.05, "En_Butr": 1.10
+    }
+    
+    calculate_An_GEIn(
+        Dt_GEIn = 100.0, Inf_NDFIn = 20.0, Inf_StIn = 15.0, Inf_FAIn = 10.0, 
+        Inf_TPIn = 25.0, Inf_NPNCPIn = 5.0, Inf_AcetIn = 8.0, Inf_PropIn = 12.0, 
+        Inf_ButrIn = 6.0, coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = [
-        'En_NDF', 'En_St', 'En_FA', 'En_CP', 'En_NPNCP', 'En_Acet', 'En_Prop',
-        'En_Butr'
-    ]
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     An_GEIn = (Dt_GEIn + 
                Inf_NDFIn * coeff_dict['En_NDF'] + 
                Inf_StIn * coeff_dict['En_St'] + 
@@ -1098,9 +1191,18 @@ def calculate_An_DERDTPIn(An_RDTPIn: float,
 ) -> float:
     """
     An_DERDTPIn: Digestable energy in rumen degradable true protein (Mcal/d)
+
+    Examples
+    --------
+    ```
+    coeff_dict = {"En_CP": 5.65}
+    
+    calculate_An_DERDTPIn(
+        An_RDTPIn = 100.0, Fe_DEMiCPend = 10.0, Fe_DERDPend = 5.0, 
+        coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['En_CP']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     An_DERDTPIn = An_RDTPIn * coeff_dict['En_CP'] - Fe_DEMiCPend - Fe_DERDPend  
     # Line 1359
     return An_DERDTPIn
@@ -1112,9 +1214,17 @@ def calculate_An_DEidRUPIn(An_idRUPIn: float,
 ) -> float:
     """
     An_DEidRUPIn: Digestable energy in intestinally digested RUP (Mcal/d)
+    
+    Examples
+    --------
+    ```
+    coeff_dict = {"En_CP": 5.65}
+    
+    calculate_An_DEidRUPIn(
+        An_idRUPIn = 80.0, Fe_DERUPend = 15.0, coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['En_CP']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     An_DEidRUPIn = An_idRUPIn * coeff_dict['En_CP'] - Fe_DERUPend  # Line 1360
     return An_DEidRUPIn
 

--- a/src/nasem_dairy/nasem_equations/body_composition.py
+++ b/src/nasem_dairy/nasem_equations/body_composition.py
@@ -29,8 +29,15 @@ def calculate_Body_Gain_empty(Frm_Gain_empty: float,
 
 
 def calculate_NPGain_RsrvGain(coeff_dict: dict) -> float:
-    req_coeff = ['CPGain_RsrvGain', 'Body_NP_CP']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {"CPGain_RsrvGain": 0.068, "Body_NP_CP": 0.86}
+    
+    calculate_NPGain_RsrvGain(coeff_dict = coeff_dict)
+    ```
+    """
     NPGain_RsrvGain = coeff_dict['CPGain_RsrvGain'] * coeff_dict['Body_NP_CP']  
     # Line 2467
     return NPGain_RsrvGain
@@ -49,8 +56,17 @@ def calculate_Body_NPgain(Frm_NPgain: float, Rsrv_NPgain: float) -> float:
 
 
 def calculate_Body_CPgain(Body_NPgain: float, coeff_dict: dict) -> float:
-    req_coeff = ['Body_NP_CP']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {"Body_NP_CP": 0.86}
+    
+    calculate_Body_CPgain(
+        Body_NPgain = 50.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     Body_CPgain = Body_NPgain / coeff_dict['Body_NP_CP']  # Line 2475
     return Body_CPgain
 
@@ -81,9 +97,17 @@ def calculate_Rsrv_Fatgain(Rsrv_Gain_empty: float, coeff_dict: dict) -> float:
     """
     FatGain_RsrvGain: Conversion factor from reserve gain to fat gain
     Rsrv_Fatgain: Body reserve fat gain kg/d
+    
+    Examples
+    --------
+    ```
+    coeff_dict = {"FatGain_RsrvGain": 0.622}
+    
+    calculate_Rsrv_Fatgain(
+        Rsrv_Gain_empty = 40.0, coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['FatGain_RsrvGain']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     Rsrv_Fatgain = coeff_dict['FatGain_RsrvGain'] * Rsrv_Gain_empty  # Line 2453
     return Rsrv_Fatgain
 
@@ -154,9 +178,17 @@ def calculate_NPGain_FrmGain(CPGain_FrmGain: float, coeff_dict: dict) -> float:
     """
     NPGain_FrmGain: Net protein gain per unit frame gain
     NOTE for these gain per unit gain values I believe they are unitless/have units g/g, not much said in the R code
+    
+    Examples
+    --------
+    ```
+    coeff_dict = {"Body_NP_CP": 0.86}
+    
+    calculate_NPGain_FrmGain(
+        CPGain_FrmGain = 60.0, coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['Body_NP_CP']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     # Convert to CP to TP gain / gain, Line 2459
     NPGain_FrmGain = CPGain_FrmGain * coeff_dict['Body_NP_CP']
     return NPGain_FrmGain
@@ -181,9 +213,17 @@ def calculate_Frm_NPgain(An_StatePhys: str,
 def calculate_Frm_CPgain(Frm_NPgain: float, coeff_dict: dict) -> float:
     """
     Frm_CPgain: CP portion of frame gain
+
+    Examples
+    --------
+    ```
+    coeff_dict = {"Body_NP_CP": 0.86}
+    
+    calculate_Frm_CPgain(
+        Frm_NPgain = 50.0, coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['Body_NP_CP']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     Frm_CPgain = Frm_NPgain / coeff_dict['Body_NP_CP']  # Line 2463
     return Frm_CPgain
 
@@ -201,9 +241,17 @@ def calculate_An_BWmature_empty(An_BW_mature: float,
 ) -> float:
     """
     An_BWmature_empty: kg bodyweight with no gut fill 
+
+    Examples
+    --------
+    ```
+    coeff_dict = {"An_GutFill_BWmature": 0.18}
+    
+    calculate_An_BWmature_empty(
+        An_BW_mature = 600.0, coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['An_GutFill_BWmature']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     An_BWmature_empty = An_BW_mature * (1 - coeff_dict['An_GutFill_BWmature'])
     return An_BWmature_empty
 
@@ -452,9 +500,17 @@ def calculate_WatGain_RsrvGain(NPGain_RsrvGain: float,
 ) -> float:
     """
     WatGain_RsrvGain: Body reserve water gain (g/g)
+    
+    Examples
+    --------
+    ```
+    coeff_dict = {"FatGain_RsrvGain": 0.622, "AshGain_RsrvGain": 0.02}
+    
+    calculate_WatGain_RsrvGain(
+        NPGain_RsrvGain = 0.20, coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['FatGain_RsrvGain', 'AshGain_RsrvGain']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     WatGain_RsrvGain = (100 - coeff_dict['FatGain_RsrvGain'] - NPGain_RsrvGain - 
                         coeff_dict['AshGain_RsrvGain'])  # Line 2489
     return WatGain_RsrvGain
@@ -515,9 +571,18 @@ def calculate_Body_CPgain_MPalowTrg_g(Body_NPgain_MPalowTrg_g: float,
 ) -> float:
     """
     Body_CPgain_MPalowTrg_g: MP allowable CP gain (g/d)
+    
+    Examples
+    --------
+    ```
+    coeff_dict = {"Body_NP_CP": 0.80}
+    
+    calculate_Body_CPgain_MPalowTrg_g(
+        Body_NPgain_MPalowTrg_g = 40.0, 
+        coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['Body_NP_CP']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     Body_CPgain_MPalowTrg_g = Body_NPgain_MPalowTrg_g / coeff_dict['Body_NP_CP']  
     # g CP gain/d, Line 2714
     return Body_CPgain_MPalowTrg_g
@@ -631,7 +696,16 @@ def calculate_An_Days_BCSdelta1(BW_BCS: float,
 def calculate_Rsrv_AshGain(Rsrv_Gain_empty: float,
                            coeff_dict: dict
 ) -> float:
-    req_coeff = ["AshGain_RsrvGain"]
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {"AshGain_RsrvGain": 0.02}
+    
+    calculate_Rsrv_AshGain(
+        Rsrv_Gain_empty = 40.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     Rsrv_AshGain = coeff_dict["AshGain_RsrvGain"] * Rsrv_Gain_empty   # Line 2481
     return Rsrv_AshGain

--- a/src/nasem_dairy/nasem_equations/body_composition.py
+++ b/src/nasem_dairy/nasem_equations/body_composition.py
@@ -5,8 +5,6 @@ import math
 
 import numpy as np
 
-import nasem_dairy.model.utilities as ration_funcs
-
 
 def calculate_Frm_Gain_empty(Frm_Gain: float, 
                              Dt_DMIn_ClfLiq: float, 

--- a/src/nasem_dairy/nasem_equations/dry_matter_intake.py
+++ b/src/nasem_dairy/nasem_equations/dry_matter_intake.py
@@ -82,8 +82,17 @@ def calculate_Dt_DMIn_BW_LateGest_i(An_PrePartWklim: Union[int, float],
                                     Kb_LateGest_DMIn: float,
                                     coeff_dict: dict
 ) -> float:
-    req_coeffs = ['Ka_LateGest_DMIn', 'Kc_LateGest_DMIn']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeffs)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {"Ka_LateGest_DMIn": 1.47, "Kc_LateGest_DMIn": -0.035}
+    
+    calculate_Dt_DMIn_BW_LateGest_i(
+        An_PrePartWklim = 6.0, Kb_LateGest_DMIn = 0.05, coeff_dict = coeff_dict
+    )
+    ```
+    """
     # Late gestation individual animal prediction, % of BW.  Use to assess for a
     # specific day for a given animal
     Dt_DMIn_BW_LateGest_i = (coeff_dict['Ka_LateGest_DMIn'] + 
@@ -97,8 +106,20 @@ def calculate_Dt_DMIn_BW_LateGest_p(An_PrePartWkDurat: Union[int, float],
                                     Kb_LateGest_DMIn: float,
                                     coeff_dict: dict
 ) -> float:
-    req_coeffs = ['Ka_LateGest_DMIn', 'Kc_LateGest_DMIn']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeffs)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {
+        "Ka_LateGest_DMIn": 1.47, "Kc_LateGest_DMIn": -0.035
+    }
+    
+    calculate_Dt_DMIn_BW_LateGest_p(
+        An_PrePartWkDurat = 6.0, Kb_LateGest_DMIn = 0.05, 
+        coeff_dict = coeff_dict
+    )
+    ```
+    """
     # Late gestation Group/Pen mean DMI/BW for an interval of 0 to 
     # PrePart_WkDurat. Assumes pen steady state and PrePart_wk = pen mean
     Dt_DMIn_BW_LateGest_p = (coeff_dict['Ka_LateGest_DMIn'] * An_PrePartWkDurat

--- a/src/nasem_dairy/nasem_equations/dry_matter_intake.py
+++ b/src/nasem_dairy/nasem_equations/dry_matter_intake.py
@@ -23,7 +23,6 @@ Example of how to use this module:
 import math
 from typing import Union
 
-import nasem_dairy.model.utilities as ration_funcs
 
 # Precalculation for heifer DMI predicitons
 def calculate_Kb_LateGest_DMIn(Dt_NDF: float) -> float:

--- a/src/nasem_dairy/nasem_equations/energy_requirement.py
+++ b/src/nasem_dairy/nasem_equations/energy_requirement.py
@@ -333,8 +333,6 @@ def calculate_An_NEmUse(An_NEmUse_NS: float,
     )
     ```
     """
-    req_coeff = ['An_NEmUse_Env']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     An_NEmUse = An_NEmUse_NS + coeff_dict['An_NEmUse_Env'] + An_NEmUse_Act  
     # Line 2802
     return An_NEmUse
@@ -635,9 +633,19 @@ def calculate_Kf_ME_RE(An_StatePhys: str,
                        Dt_DMIn: float,
                        coeff_dict: dict
 ) -> float:
-    req_coeff = ['Kf_ME_RE_ClfLiq']  # Equation 20-223
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
-    if An_StatePhys == "Calf":
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {"Kf_ME_RE_ClfLiq": 0.56}
+    
+    calculate_Kf_ME_RE(
+        An_StatePhys = "Calf", Kf_ME_RE_ClfDry = 0.5, Dt_DMIn_ClfLiq = 2.0, 
+        Dt_DMIn = 5.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
+    if An_StatePhys == "Calf": # Equation 20-223
         Kf_ME_RE = (coeff_dict['Kf_ME_RE_ClfLiq'] * Dt_DMIn_ClfLiq / Dt_DMIn + 
                     Kf_ME_RE_ClfDry * (Dt_DMIn - Dt_DMIn_ClfLiq) / Dt_DMIn)
     else:
@@ -866,8 +874,6 @@ def calculate_Trg_Mlk_MEout(Trg_Mlk_NEout: float, coeff_dict: dict) -> float:
     )
     ```
     """
-    req_coeff = ['Kl_ME_NE']  # Equation 20-223
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     Trg_Mlk_MEout = Trg_Mlk_NEout / coeff_dict['Kl_ME_NE']  
     # Line 2890 Equation 20-222
     return Trg_Mlk_MEout
@@ -945,9 +951,17 @@ def calculate_An_MEmUse_Act(An_NEmUse_Act: float, Km_ME_NE: float) -> float:
 def calculate_An_MEmUse_Env(Km_ME_NE: float, coeff_dict: dict) -> float:
     """
     An_MEmUse_Env: Metabolizable energy lost to the environment (Mcal/d)
+    
+    Examples
+    --------
+    ```
+    coeff_dict = {"An_NEmUse_Env": 0}
+    
+    calculate_An_MEmUse_Env(
+        Km_ME_NE = 0.8, coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['An_NEmUse_Env']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     An_MEmUse_Env = coeff_dict['An_NEmUse_Env'] / Km_ME_NE # Line 2848
     return An_MEmUse_Env
 
@@ -987,9 +1001,17 @@ def calculate_An_NEmAct_DE(An_NEmUse_Act: float, An_DEIn: float) -> float:
 def calculate_An_NEmEnv_DE(An_DEIn: float, coeff_dict: dict) -> float:
     """
     An_NEmEnv_DE: NE lost to environment as proportion of DE intake (Mcal/Mcal)
+    
+    Examples
+    --------
+    ```
+    coeff_dict = {"An_NEmUse_Env": 0}
+    
+    calculate_An_NEmEnv_DE(
+        An_DEIn = 50.0, coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['An_NEmUse_Env']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     An_NEmEnv_DE = coeff_dict['An_NEmUse_Env'] / An_DEIn  # Line 2853
     return An_NEmEnv_DE
 
@@ -1013,9 +1035,17 @@ def calculate_An_MEprod_Avail(An_MEIn: float, An_MEmUse: float) -> float:
 def calculate_Gest_NELuse(Gest_MEuse: float, coeff_dict: dict) -> float:
     """
     Gest_NELuse: NE lactation used for gestation (Mcal/d)
+    
+    Examples
+    --------
+    ```
+    coeff_dict = {"Kl_ME_NE": 0.66}
+    
+    calculate_Gest_NELuse(
+        Gest_MEuse = 100.0, coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['Kl_ME_NE']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     Gest_NELuse = Gest_MEuse * coeff_dict['Kl_ME_NE']  
     # mcal/d ME required. ??This should not be used, delete. Line 2861
     return Gest_NELuse
@@ -1093,9 +1123,17 @@ def calculate_An_ME_NEg(An_REgain: float, An_MEgain: float) -> float:
 def calculate_Rsrv_NELgain(Rsrv_MEgain: float, coeff_dict: dict) -> float:
     """
     Rsrv_NELgain: NEL required for body reserve gain (Mcal/d)
+
+    Examples
+    --------
+    ```
+    coeff_dict = {"Kl_ME_NE": 0.66}
+    
+    calculate_Rsrv_NELgain(
+        Rsrv_MEgain = 120.0, coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['Kl_ME_NE']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     Rsrv_NELgain = Rsrv_MEgain * coeff_dict['Kl_ME_NE']  
     # express body energy required in NEL terms, Line 2877
     return Rsrv_NELgain
@@ -1104,9 +1142,17 @@ def calculate_Rsrv_NELgain(Rsrv_MEgain: float, coeff_dict: dict) -> float:
 def calculate_Frm_NELgain(Frm_MEgain: float, coeff_dict: dict) -> float:
     """
     Frm_NELgain: NEL required for frame gain (Mcal/d)
+
+    Examples
+    --------
+    ```
+    coeff_dict = {"Kl_ME_NE": 0.66}
+    
+    calculate_Frm_NELgain(
+        Frm_MEgain = 80.0, coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['Kl_ME_NE']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     Frm_NELgain = Frm_MEgain * coeff_dict['Kl_ME_NE']  # Line 2878
     return Frm_NELgain
 
@@ -1114,9 +1160,17 @@ def calculate_Frm_NELgain(Frm_MEgain: float, coeff_dict: dict) -> float:
 def calculate_An_NELgain(An_MEgain: float, coeff_dict: dict) -> float:
     """
     An_NELgain: NEL required for bodyweight gain (Mcal/d)
+
+    Examples
+    --------
+    ```
+    coeff_dict = {"Kl_ME_NE": 0.66}
+    
+    calculate_An_NELgain(
+        An_MEgain = 150.0, coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['Kl_ME_NE']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     An_NELgain = An_MEgain * coeff_dict['Kl_ME_NE']  # Line 2879
     return An_NELgain
 
@@ -1176,9 +1230,17 @@ def calculate_Trg_NEuse(An_NEmUse: float,
 def calculate_An_NELuse(An_MEuse: float, coeff_dict: dict) -> float:
     """
     An_NELuse: Total NEL requirement (Mcal/d)
+    
+    Examples
+    --------
+    ```
+    coeff_dict = {"Kl_ME_NE": 0.66}
+    
+    calculate_An_NELuse(
+        An_MEuse = 100.0, coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['Kl_ME_NE']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     An_NELuse = An_MEuse * coeff_dict['Kl_ME_NE']  # Line 2927
     return An_NELuse
 
@@ -1186,9 +1248,17 @@ def calculate_An_NELuse(An_MEuse: float, coeff_dict: dict) -> float:
 def calculate_Trg_NELuse(Trg_MEuse: float, coeff_dict: dict) -> float:
     """
     Trg_NELuse: Target NEL requirement (Mcal/d)
+
+    Examples
+    --------
+    ```
+    coeff_dict = {"Kl_ME_NE": 0.66}
+    
+    calculate_Trg_NELuse(
+        Trg_MEuse = 90.0, coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['Kl_ME_NE']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     Trg_NELuse = Trg_MEuse * coeff_dict['Kl_ME_NE']  # Line 2928
     return Trg_NELuse
 
@@ -1246,9 +1316,17 @@ def calculate_An_MEbal(An_MEIn: float, An_MEuse: float) -> float:
 def calculate_An_NELbal(An_MEbal: float, coeff_dict: dict) -> float:
     """
     An_NELbal: NEL balance (Mcal/d)
+    
+    Examples
+    --------
+    ```
+    coeff_dict = {"Kl_ME_NE": 0.66}
+    
+    calculate_An_NELbal(
+        An_MEbal = 50.0, coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['Kl_ME_NE']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     An_NELbal = An_MEbal * coeff_dict['Kl_ME_NE']  # Line 2936
     return An_NELbal
 
@@ -1272,9 +1350,17 @@ def calculate_Trg_MEbal(An_MEIn: float, Trg_MEuse: float) -> float:
 def calculate_Trg_NELbal(Trg_MEbal: float, coeff_dict: dict) -> float:
     """
     Trg_NELbal: Target NEL balance (Mcal/d)
+    
+    Examples
+    --------
+    ```
+    coeff_dict = {"Kl_ME_NE": 0.66}
+    
+    calculate_Trg_NELbal(
+        Trg_MEbal = 70.0, coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['Kl_ME_NE']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     Trg_NELbal = Trg_MEbal * coeff_dict['Kl_ME_NE']  # Line 2940
     return Trg_NELbal
 

--- a/src/nasem_dairy/nasem_equations/energy_requirement.py
+++ b/src/nasem_dairy/nasem_equations/energy_requirement.py
@@ -2,7 +2,6 @@
 
 import numpy as np
 
-import nasem_dairy.model.utilities as ration_funcs
 
 def calculate_An_NEmUse_NS(An_StatePhys: str, 
                            An_BW: float, 

--- a/src/nasem_dairy/nasem_equations/fecal.py
+++ b/src/nasem_dairy/nasem_equations/fecal.py
@@ -8,8 +8,17 @@ import nasem_dairy.model.utilities as ration_funcs
 
 
 def calculate_Fe_rOMend(Dt_DMIn: float, coeff_dict: dict) -> float:
-    req_coeff = ['Fe_rOMend_DMI']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {"Fe_rOMend_DMI": 3.43}
+    
+    calculate_Fe_rOMend(
+        Dt_DMIn = 30.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     # Line 1007, From Tebbe et al., 2017. Negative interecept represents endogenous rOM
     Fe_rOMend = coeff_dict['Fe_rOMend_DMI'] / 100 * Dt_DMIn
     return Fe_rOMend
@@ -75,8 +84,19 @@ def calculate_Fe_CP(An_StatePhys: str,
                     InfSI_NPNCPIn: float, 
                     coeff_dict: dict
 ) -> float:
-    req_coeff = ['dcNPNCP', 'Dt_dcCP_ClfLiq']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {"dcNPNCP": 100, "Dt_dcCP_ClfLiq": 0.95}
+    
+    calculate_Fe_CP(
+        An_StatePhys = "Adult", Dt_CPIn_ClfLiq = 10.0, Dt_dcCP_ClfDry = 0.75, 
+        An_CPIn = 50.0, Fe_RUP = 5.0, Fe_RumMiCP = 3.0, Fe_CPend = 2.0, 
+        InfSI_NPNCPIn = 4.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     # Line 1202, Double counting portion of RumMiCP derived from End CP. Needs to be fixed. MDH
     Fe_CP = (Fe_RUP + Fe_RumMiCP + Fe_CPend + 
              InfSI_NPNCPIn * (1 - coeff_dict['dcNPNCP'] / 100))
@@ -269,9 +289,17 @@ def calculate_Fe_OM_end(Fe_rOMend: float, Fe_CPend: float) -> float:
 def calculate_Fe_DEMiCPend(Fe_RumMiCP: float, coeff_dict: dict) -> float:
     """
     Fe_DEMiCPend: Digestable energy in undigested ruminacl MiCP and RDP (Mcal/d)
+    
+    Examples
+    --------
+    ```
+    coeff_dict = {"En_CP": 5.65}
+    
+    calculate_Fe_DEMiCPend(
+        Fe_RumMiCP = 20.0, coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['En_CP']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     Fe_DEMiCPend = Fe_RumMiCP * coeff_dict['En_CP']
     # DE in undigested ruminal MiCP and RDP portion of Fe_EndCP, Line 1356
     return Fe_DEMiCPend
@@ -280,9 +308,17 @@ def calculate_Fe_DEMiCPend(Fe_RumMiCP: float, coeff_dict: dict) -> float:
 def calculate_Fe_DERDPend(Fe_RDPend: float, coeff_dict: dict) -> float:
     """
     Fe_DERDPend: Digestable energy in fecal RDP, arbitrary value (Mcal/d)
+    
+    Examples
+    --------
+    ```
+    coeff_dict = {"En_CP": 5.65}
+    
+    calculate_Fe_DERDPend(
+        Fe_RDPend = 15.0, coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['En_CP']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     Fe_DERDPend = Fe_RDPend * coeff_dict['En_CP']
     # Arbitrary DE assignment of Fe_CPend DE to RDP and RUP. Reporting use only, Line 1357
     return Fe_DERDPend
@@ -291,9 +327,17 @@ def calculate_Fe_DERDPend(Fe_RDPend: float, coeff_dict: dict) -> float:
 def calculate_Fe_DERUPend(Fe_RUPend: float, coeff_dict: dict) -> float:
     """
     Fe_DERUPend: Digestable energy in fecal RUP, arbitrary value (Mcal/d)
+    
+    Examples
+    --------
+    ```
+    coeff_dict = {"En_CP": 5.65}
+    
+    calculate_Fe_DERUPend(
+        Fe_RUPend = 10.0, coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['En_CP']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     Fe_DERUPend = Fe_RUPend * coeff_dict['En_CP']  # Line 1358
     return Fe_DERUPend
 

--- a/src/nasem_dairy/nasem_equations/fecal.py
+++ b/src/nasem_dairy/nasem_equations/fecal.py
@@ -4,8 +4,6 @@
 import numpy as np
 import pandas as pd
 
-import nasem_dairy.model.utilities as ration_funcs
-
 
 def calculate_Fe_rOMend(Dt_DMIn: float, coeff_dict: dict) -> float:
     """

--- a/src/nasem_dairy/nasem_equations/gestation.py
+++ b/src/nasem_dairy/nasem_equations/gestation.py
@@ -5,8 +5,6 @@ import math
 import numpy as np
 import pandas as pd
 
-import nasem_dairy.model.utilities as ration_funcs
-
 
 def calculate_Uter_Wtpart(Fet_BWbrth: float, coeff_dict: dict) -> float:
     """

--- a/src/nasem_dairy/nasem_equations/gestation.py
+++ b/src/nasem_dairy/nasem_equations/gestation.py
@@ -9,8 +9,17 @@ import nasem_dairy.model.utilities as ration_funcs
 
 
 def calculate_Uter_Wtpart(Fet_BWbrth: float, coeff_dict: dict) -> float:
-    req_coeff = ['UterWt_FetBWbrth']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {"UterWt_FetBWbrth": 1.816}
+    
+    calculate_Uter_Wtpart(
+        Fet_BWbrth = 30.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     Uter_Wtpart = Fet_BWbrth * coeff_dict['UterWt_FetBWbrth']
     return Uter_Wtpart
 
@@ -23,8 +32,21 @@ def calculate_Uter_Wt(An_Parity_rl: int,
                       Uter_Wtpart: float, 
                       coeff_dict: dict
 ) -> float:
-    req_coeff = ['Uter_Wt', 'Uter_Ksyn', 'Uter_KsynDecay', 'Uter_Kdeg']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {
+        "Uter_Wt": 0.204, "Uter_Ksyn": 2.42e-2, "Uter_KsynDecay": 3.53e-5, 
+        "Uter_Kdeg": 0.20
+    }
+    
+    calculate_Uter_Wt(
+        An_Parity_rl = 1, An_AgeDay = 250, An_LactDay = 50, An_GestDay = 150, 
+        An_GestLength = 280, Uter_Wtpart = 45.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     Uter_Wt = coeff_dict['Uter_Wt']  # Line 2312
     if An_AgeDay < 240:  # Line 2313
         Uter_Wt = 0
@@ -45,12 +67,20 @@ def calculate_Uter_Wt(An_Parity_rl: int,
 
 
 def calculate_GrUter_Wtpart(Fet_BWbrth: float, coeff_dict: dict) -> float:
-    '''
+    """
     GrUterWt_FetBWbrth default 1.816 based on equation 20-225
     See Equation 3-15a, supposed to be 1.825?
-    '''
-    req_coeff = ['GrUterWt_FetBWbrth']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    
+    Examples
+    --------
+    ```
+    coeff_dict = {"GrUterWt_FetBWbrth": 1.816}
+    
+    calculate_GrUter_Wtpart(
+        Fet_BWbrth = 30.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     GrUter_Wtpart = Fet_BWbrth * coeff_dict['GrUterWt_FetBWbrth'] # Line 2322
     return GrUter_Wtpart
 
@@ -61,8 +91,20 @@ def calculate_GrUter_Wt(An_GestDay: int,
                         GrUter_Wtpart: float,
                         coeff_dict: dict
 ) -> float:
-    req_coeff = ['GrUter_Ksyn', 'GrUter_KsynDecay']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {
+        "GrUter_Ksyn": 2.43e-2, "GrUter_KsynDecay": 2.45e-5
+    }
+    
+    calculate_GrUter_Wt(
+        An_GestDay = 150, An_GestLength = 280, Uter_Wt = 40.0, 
+        GrUter_Wtpart = 55.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     GrUter_Wt = Uter_Wt
     if An_GestDay > 0 and An_GestDay <= An_GestLength:  # Line 2323-2327
         GrUter_Wt = (GrUter_Wtpart * 
@@ -80,8 +122,21 @@ def calculate_Uter_BWgain(An_LactDay: int,
                           Uter_Wt: float,
                           coeff_dict: dict
 ) -> float:
-    req_coeff = ['Uter_BWgain', 'Uter_Ksyn', 'Uter_KsynDecay', 'Uter_Kdeg']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {
+        "Uter_BWgain": 0, "Uter_Ksyn": 2.42e-2, "Uter_KsynDecay": 3.53e-5, 
+        "Uter_Kdeg": 0.20
+    }
+    
+    calculate_Uter_BWgain(
+        An_LactDay = 50, An_GestDay = 150, An_GestLength = 280, Uter_Wt = 45.0, 
+        coeff_dict = coeff_dict
+    )
+    ```
+    """
     Uter_BWgain = coeff_dict['Uter_BWgain']
     if An_GestDay > 0 and An_GestDay <= An_GestLength:
         Uter_BWgain = (coeff_dict['Uter_Ksyn'] -
@@ -99,13 +154,22 @@ def calculate_GrUter_BWgain(An_LactDay: int,
                             Uter_BWgain: float, 
                             coeff_dict: dict
 ) -> float:
-    '''
+    """
     Equation 3-17a
-    GrUter_Ksyn = 0.0243
-    GrUter_KsynDecay = 0.00000245
-    '''
-    req_coeff = ['GrUter_BWgain', 'GrUter_Ksyn', 'GrUter_KsynDecay']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    
+    Examples
+    --------
+    ```
+    coeff_dict = {
+        "GrUter_BWgain": 0, "GrUter_Ksyn": 2.43e-2, "GrUter_KsynDecay": 2.45e-5
+    }
+    
+    calculate_GrUter_BWgain(
+        An_LactDay = 50, An_GestDay = 150, An_GestLength = 280, 
+        GrUter_Wt = 50.0, Uter_BWgain = 0.5, coeff_dict = coeff_dict
+    )
+    ```
+    """
     GrUter_BWgain = coeff_dict['GrUter_BWgain']  # Line 2341-2345
     if An_GestDay > 0 and An_GestDay <= An_GestLength:
         GrUter_BWgain = (
@@ -119,29 +183,65 @@ def calculate_GrUter_BWgain(An_LactDay: int,
 def calculate_Gest_NCPgain_g(GrUter_BWgain: float, 
                              coeff_dict: dict
 ) -> float:
-    req_coeff = ['CP_GrUtWt']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {"CP_GrUtWt": 0.123}
+    
+    calculate_Gest_NCPgain_g(
+        GrUter_BWgain = 50.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     Gest_NCPgain_g = GrUter_BWgain * coeff_dict['CP_GrUtWt'] * 1000
     return Gest_NCPgain_g
 
 
 def calculate_Gest_NPgain_g(Gest_NCPgain_g: float, coeff_dict: dict) -> float:
-    req_coeff = ['Body_NP_CP']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {"Body_NP_CP": 0.86}
+    
+    calculate_Gest_NPgain_g(
+        Gest_NCPgain_g = 2.5, coeff_dict = coeff_dict
+    )
+    ```
+    """
     Gest_NPgain_g = Gest_NCPgain_g * coeff_dict['Body_NP_CP']
     return Gest_NPgain_g
 
 
 def calculate_Gest_NPuse_g(Gest_NPgain_g: float, coeff_dict: dict) -> float:
-    req_coeff = ['Gest_NPother_g']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {"Gest_NPother_g": 0}
+    
+    calculate_Gest_NPuse_g(
+        Gest_NPgain_g = 2.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     Gest_NPuse_g = Gest_NPgain_g + coeff_dict['Gest_NPother_g']  # Line 2366
     return Gest_NPuse_g
 
 
 def calculate_Gest_CPuse_g(Gest_NPuse_g: float, coeff_dict: dict) -> float:
-    req_coeff = ['Body_NP_CP']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {"Body_NP_CP": 0.86}
+    
+    calculate_Gest_CPuse_g(
+        Gest_NPuse_g = 2.1, coeff_dict = coeff_dict
+    )
+    ```
+    """
     Gest_CPuse_g = Gest_NPuse_g / coeff_dict['Body_NP_CP']  # Line 2367
     return Gest_CPuse_g
 
@@ -180,9 +280,18 @@ def calculate_Fet_Wt(An_GestDay: int,
 ) -> float:
     """
     Fet_Wt: Fetal weight at any time (kg)
+    
+    Examples
+    --------
+    ```
+    coeff_dict = {"Fet_Ksyn": 5.16e-2, "Fet_KsynDecay": 7.59e-5}
+    
+    calculate_Fet_Wt(
+        An_GestDay = 150, An_GestLength = 280, Fet_BWbrth = 40.0, 
+        coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['Fet_Ksyn', 'Fet_KsynDecay']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     if (An_GestDay > 0) & (An_GestDay <= An_GestLength):  # Line 2231-2232
         Fet_Wt = (Fet_BWbrth * 
                   np.exp(-(coeff_dict['Fet_Ksyn'] - 

--- a/src/nasem_dairy/nasem_equations/infusion.py
+++ b/src/nasem_dairy/nasem_equations/infusion.py
@@ -56,8 +56,18 @@ def calculate_InfRum_RUPIn(InfRum_CPAIn: float,
                            Inf_KdCPB: float, 
                            coeff_dict: dict
 ) -> float:
-    req_coeff = ['fCPAdu', 'KpConc']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {"fCPAdu": 0.064, "KpConc": 5.28}
+    
+    calculate_InfRum_RUPIn(
+        InfRum_CPAIn = 50.0, InfRum_CPBIn = 30.0, InfRum_CPCIn = 20.0, 
+        InfRum_NPNCPIn = 10.0, Inf_KdCPB = 0.05, coeff_dict = coeff_dict
+    )
+    ```
+    """
     InfRum_RUPIn = ((InfRum_CPAIn - InfRum_NPNCPIn) * coeff_dict['fCPAdu'] + 
                     InfRum_CPBIn * coeff_dict['KpConc'] / 
                     (Inf_KdCPB + coeff_dict['KpConc']) + InfRum_CPCIn) # Line 1084
@@ -86,8 +96,17 @@ def calculate_InfSI_idCPIn(InfSI_idTPIn: float,
                            InfSI_NPNCPIn: float, 
                            coeff_dict: dict
 ) -> float:
-    req_coeff = ['dcNPNCP']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {"dcNPNCP": 100}
+    
+    calculate_InfSI_idCPIn(
+        InfSI_idTPIn = 40.0, InfSI_NPNCPIn = 20.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     # SI infused idTP + urea or ammonia, Line 1092
     InfSI_idCPIn = InfSI_idTPIn + InfSI_NPNCPIn * coeff_dict['dcNPNCP'] / 100
     return InfSI_idCPIn
@@ -105,30 +124,66 @@ def calculate_InfRum_RDPIn(InfRum_CPIn: float, InfRum_RUPIn: float) -> float:
 
 
 def calculate_Inf_DigFAIn(Inf_FAIn: float, coeff_dict: dict) -> float:
-    req_coeff = ['TT_dcFA_Base']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {"TT_dcFA_Base": 73}
+    
+    calculate_Inf_DigFAIn(
+        Inf_FAIn = 50.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     # Line 1306, used dcFA which is similar to oil, but should define for each infusate
     Inf_DigFAIn = Inf_FAIn * coeff_dict['TT_dcFA_Base']
     return Inf_DigFAIn
 
 
 def calculate_Inf_DEAcetIn(Inf_AcetIn: float, coeff_dict: dict) -> float:
-    req_coeffs = ['En_Acet']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeffs)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {"En_Acet": 3.48}
+    
+    calculate_Inf_DEAcetIn(
+        Inf_AcetIn = 40.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     Inf_DEAcetIn = Inf_AcetIn * coeff_dict['En_Acet']
     return Inf_DEAcetIn
 
 
 def calculate_Inf_DEPropIn(Inf_PropIn: float, coeff_dict: dict) -> float:
-    req_coeff = ['En_Prop']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {"En_Prop": 4.96}
+    
+    calculate_Inf_DEPropIn(
+        Inf_PropIn = 30.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     Inf_DEPropIn = Inf_PropIn * coeff_dict['En_Prop']  # Line 1363
     return Inf_DEPropIn
 
 
 def calculate_Inf_DEButrIn(Inf_ButrIn: float, coeff_dict: dict) -> float:
-    req_coeff = ['En_Butr']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {"En_Butr": 5.95}
+    
+    calculate_Inf_DEButrIn(
+        Inf_ButrIn = 20.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     Inf_DEButrIn = Inf_ButrIn * coeff_dict['En_Butr']
     return Inf_DEButrIn
 

--- a/src/nasem_dairy/nasem_equations/infusion.py
+++ b/src/nasem_dairy/nasem_equations/infusion.py
@@ -2,7 +2,6 @@
 
 import numpy as np
 
-import nasem_dairy.model.utilities as ration_funcs
 
 def calculate_Inf_TPIn(Inf_CPIn: float, Inf_NPNCPIn: float) -> float:
     Inf_TPIn = Inf_CPIn - Inf_NPNCPIn  # Line 848

--- a/src/nasem_dairy/nasem_equations/microbial_protein.py
+++ b/src/nasem_dairy/nasem_equations/microbial_protein.py
@@ -15,8 +15,17 @@ def calculate_RDPIn_MiNmax(Dt_DMIn: float,
 
 
 def calculate_MiN_Vm(RDPIn_MiNmax: float, coeff_dict: dict) -> float:
-    req_coeffs = ['VmMiNInt', 'VmMiNRDPSlp']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeffs)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {"VmMiNInt": 100.8, "VmMiNRDPSlp": 81.56}
+    
+    calculate_MiN_Vm(
+        RDPIn_MiNmax = 100.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     MiN_Vm = coeff_dict['VmMiNInt'] + coeff_dict['VmMiNRDPSlp'] * RDPIn_MiNmax     
     # Line 1125
     return MiN_Vm
@@ -28,8 +37,18 @@ def calculate_Du_MiN_NRC2021_g(MiN_Vm: float,
                                An_RDPIn_g: float,
                                coeff_dict: dict
 ) -> float:
-    req_coeffs = ['KmMiNRDNDF', 'KmMiNRDSt']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeffs)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {"KmMiNRDNDF": 0.0939, "KmMiNRDSt": 0.0274}
+    
+    calculate_Du_MiN_NRC2021_g(
+        MiN_Vm = 25.0, Rum_DigNDFIn = 200.0, Rum_DigStIn = 150.0, 
+        An_RDPIn_g = 300.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     Du_MiN_NRC2021_g = (MiN_Vm / (1 + coeff_dict['KmMiNRDNDF'] / Rum_DigNDFIn + 
                                   coeff_dict['KmMiNRDSt'] / Rum_DigStIn)) # Line 1126
     if Du_MiN_NRC2021_g > 1 * An_RDPIn_g / 6.25:  # Line 1130
@@ -46,12 +65,23 @@ def calculate_Du_MiN_VTln_g(Dt_rOMIn: float,
                             Rum_DigNDFIn: float, 
                             coeff_dict: dict
 ) -> float:
-    req_coeffs = [
-        'Int_MiN_VT', 'KrdSt_MiN_VT', 'KrdNDF_MiN_VT', 'KRDP_MiN_VT',
-        'KrOM_MiN_VT', 'KForNDF_MiN_VT', 'KrOM2_MiN_VT', 'KrdStxrOM_MiN_VT',
-        'KrdNDFxForNDF_MiN_VT'
-    ]
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeffs)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {
+        "Int_MiN_VT": 18.686, "KrdSt_MiN_VT": 10.214, "KrdNDF_MiN_VT": 28.976, 
+        "KRDP_MiN_VT": 43.405, "KrOM_MiN_VT": -11.731, "KForNDF_MiN_VT": 8.895, 
+        "KrOM2_MiN_VT": 2.861, "KrdStxrOM_MiN_VT": 5.637, 
+        "KrdNDFxForNDF_MiN_VT": -2.22
+    }
+    
+    calculate_Du_MiN_VTln_g(
+        Dt_rOMIn = 300.0, Dt_ForNDFIn = 100.0, An_RDPIn = 200.0, 
+        Rum_DigStIn = 150.0, Rum_DigNDFIn = 250.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     # Line 1144-1146
     Du_MiN_VTln_g = (coeff_dict['Int_MiN_VT'] + 
                      coeff_dict['KrdSt_MiN_VT'] * Rum_DigStIn + 
@@ -81,8 +111,17 @@ def calculate_Du_MiCP(Du_MiCP_g: float) -> float:
 
 
 def calculate_Du_idMiCP_g(Du_MiCP_g: float, coeff_dict: dict) -> float:
-    req_coeff = ['SI_dcMiCP']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {"SI_dcMiCP": 80}
+    
+    calculate_Du_idMiCP_g(
+        Du_MiCP_g = 200.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     Du_idMiCP_g = coeff_dict['SI_dcMiCP'] / 100 * Du_MiCP_g  # Line 1180
     return Du_idMiCP_g
 
@@ -93,8 +132,17 @@ def calculate_Du_idMiCP(Du_idMiCP_g: float) -> float:
 
 
 def calculate_Du_idMiTP_g(Du_idMiCP_g: float, coeff_dict: dict) -> float:
-    req_coeff = ['fMiTP_MiCP']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {"fMiTP_MiCP": 0.824}
+    
+    calculate_Du_idMiTP_g(
+        Du_idMiCP_g = 160.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     Du_idMiTP_g = coeff_dict['fMiTP_MiCP'] * Du_idMiCP_g  # Line 1182
     return Du_idMiTP_g
 

--- a/src/nasem_dairy/nasem_equations/microbial_protein.py
+++ b/src/nasem_dairy/nasem_equations/microbial_protein.py
@@ -1,7 +1,5 @@
 # import nasem_dairy.nasem_equations.microbial_protein as micp 
 
-import nasem_dairy.model.utilities as ration_funcs
-
 
 def calculate_RDPIn_MiNmax(Dt_DMIn: float, 
                            An_RDP: float, 

--- a/src/nasem_dairy/nasem_equations/milk.py
+++ b/src/nasem_dairy/nasem_equations/milk.py
@@ -85,11 +85,29 @@ def calculate_Mlk_NP_g(An_StatePhys: str,
                        An_DENDFIn: float,
                        mPrt_coeff: dict
 ) -> float:
-    req_coeff = [
-        'mPrt_k_NEAA', 'mPrt_k_OthAA', 'mPrt_k_DEInp', 'mPrt_k_DigNDF',
-        'mPrt_k_DEIn_StFA', 'mPrt_k_DEIn_NDF', 'mPrt_k_BW'
-    ]
-    ration_funcs.check_coeffs_in_coeff_dict(mPrt_coeff, req_coeff)
+    """
+    Examples
+    --------
+    ```python
+    mPrt_coeff = {
+        'mPrt_k_NEAA': 0, 'mPrt_k_OthAA': 0.07773, 'mPrt_k_DEInp': 10.79,
+        'mPrt_k_DigNDF': -4.595, 'mPrt_k_DEIn_StFA': 0, 'mPrt_k_DEIn_NDF': 0,
+        'mPrt_k_BW': -0.4201, 'mPrt_Int': -97.0
+    }
+    Abs_AA_g = pd.Series({'Arg': 1.0, 'His': 0.5, 'Ile': 1.2, 'Leu': 1.5, 'Lys': 1.1,
+                           'Met': 0.8, 'Phe': 1.0, 'Thr': 0.9, 'Trp': 0.7, 'Val': 1.3})
+    mPrt_k_AA = pd.Series({'Arg': 0.02, 'His': 0.03, 'Ile': 0.04, 'Leu': 0.05, 'Lys': 0.06,
+                           'Met': 0.07, 'Phe': 0.08, 'Thr': 0.09, 'Trp': 0.10, 'Val': 0.11})
+
+    calculate_Mlk_NP_g(
+        An_StatePhys = "Lactating Cow", mPrt_eqn = 1, Trg_Mlk_NP_g = 100.0, 
+        An_BW = 650, Abs_AA_g = Abs_AA_g, mPrt_k_AA = mPrt_k_AA, Abs_neAA_g = 0.5, 
+        Abs_OthAA_g = 0.3, Abs_EAA2b_g = 0.4, mPrt_k_EAA2 = 0.2, An_DigNDF = 25.0, 
+        An_DEInp = 30.0, An_DEStIn = 15.0, An_DEFAIn = 10.0, An_DErOMIn = 5.0, 
+        An_DENDFIn = 20.0, mPrt_coeff = mPrt_coeff
+    )
+    ```
+    """
     if An_StatePhys != "Lactating Cow":  # Line 2204
         Mlk_NP_g = 0
     elif mPrt_eqn == 0:
@@ -271,9 +289,17 @@ def calculate_Mlk_NP_MPalow_Trg_g(An_MPavail_Milk_Trg: float,
 ) -> float:
     """
     Mlk_NP_MPalow_Trg_g: net protein available for milk production, g milk NP/d
+    
+    Examples
+    --------
+    ```python
+    coeff_dict = {"Kx_MP_NP_Trg": 0.69}
+    
+    calculate_Mlk_NP_MPalow_Trg_g(
+        An_MPavail_Milk_Trg = 5.0, coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['Kx_MP_NP_Trg']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     Mlk_NP_MPalow_Trg_g = An_MPavail_Milk_Trg * coeff_dict['Kx_MP_NP_Trg'] * 1000  
     # g milk NP/d, Line 2707
     return Mlk_NP_MPalow_Trg_g
@@ -311,9 +337,17 @@ def calculate_Mlk_Prod_NEalow(An_MEavail_Milk: float,
 ) -> float:
     """
     Mlk_Prod_NEalow: Net energy allowable milk production, kg/d
+    
+    Examples
+    --------
+    ```python
+    coeff_dict = {"Kl_ME_NE": 0.66}
+    
+    calculate_Mlk_Prod_NEalow(
+        An_MEavail_Milk = 12.0, Trg_NEmilk_Milk = 1.5, coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['Kl_ME_NE']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     if Trg_NEmilk_Milk != 0 and not np.isnan(Trg_NEmilk_Milk):
         Mlk_Prod_NEalow = An_MEavail_Milk * coeff_dict['Kl_ME_NE'] / Trg_NEmilk_Milk
     else:
@@ -403,9 +437,17 @@ def calculate_Mlk_NEout(MlkNE_Milk: float, Mlk_Prod: float) -> float:
 def calculate_Mlk_MEout(Mlk_NEout: float, coeff_dict: dict) -> float:
     """
     Mlk_MEout: Total ME in milk Mcal/d
+
+    Examples
+    --------
+    ```python
+    coeff_dict = {"Kl_ME_NE": 0.66}
+    
+    calculate_Mlk_MEout(
+        Mlk_NEout = 3.0, coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeffs = ['Kl_ME_NE']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeffs)
     Mlk_MEout = Mlk_NEout / coeff_dict['Kl_ME_NE']
     return Mlk_MEout
 
@@ -623,8 +665,6 @@ def calculate_MlkNP_Int(An_BW: float, mPrt_coeff: dict) -> float:
     """
     MlkNP_Int: ?
     """
-    # req_coeff = ['mPrt_Int', 'mPrt_k_BW']
-    # ration_funcs.check_coeffs_in_coeff_dict(mPrt_coeff, req_coeff)
     MlkNP_Int = mPrt_coeff['mPrt_Int'] + (An_BW - 612) * mPrt_coeff['mPrt_k_BW']
     # Line 3179
     return MlkNP_Int
@@ -634,8 +674,6 @@ def calculate_MlkNP_DEInp(An_DEInp: float, mPrt_coeff: dict) -> float:
     """
     MlkNP_DEInp: ?
     """
-    # req_coeff = ['mPrt_k_DEInp']
-    # ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     MlkNP_DEInp = An_DEInp * mPrt_coeff['mPrt_k_DEInp']  # Line 3180
     return MlkNP_DEInp
 
@@ -644,8 +682,6 @@ def calculate_MlkNP_NDF(An_DigNDF: float, mPrt_coeff: dict) -> float:
     """
     MlkNP_NDF: ?
     """
-    # req_coeff = ['mPrt_k_DigNDF']
-    # ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     MlkNP_NDF = (An_DigNDF - 17.06) * mPrt_coeff['mPrt_k_DigNDF']
     return MlkNP_NDF
 
@@ -672,8 +708,6 @@ def calculate_MlkNP_AbsNEAA(Abs_neAA_g: float, mPrt_coeff: dict) -> float:
     """
     MlkNP_AbsNEAA: ? 
     """
-    # req_coeff = ['mPrt_k_NEAA']
-    # ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     MlkNP_AbsNEAA = Abs_neAA_g * mPrt_coeff['mPrt_k_NEAA']  # Line 3193
     return MlkNP_AbsNEAA
 
@@ -682,8 +716,6 @@ def calculate_MlkNP_AbsOthAA(Abs_OthAA_g: float, mPrt_coeff: dict) -> float:
     """
     MlkNP_AbsOthAA: ?
     """
-    # req_coeff = ['mPrt_k_OthAA']
-    # ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     MlkNP_AbsOthAA = Abs_OthAA_g * mPrt_coeff['mPrt_k_OthAA']
     return MlkNP_AbsOthAA
 

--- a/src/nasem_dairy/nasem_equations/milk.py
+++ b/src/nasem_dairy/nasem_equations/milk.py
@@ -4,8 +4,6 @@
 import numpy as np
 import pandas as pd
 
-import nasem_dairy.model.utilities as ration_funcs
-
 
 def calculate_Trg_NEmilk_Milk(Trg_MilkFatp: float, 
                               Trg_MilkTPp: float,

--- a/src/nasem_dairy/nasem_equations/nutrient_intakes.py
+++ b/src/nasem_dairy/nasem_equations/nutrient_intakes.py
@@ -65,9 +65,29 @@ def calculate_Fd_GE(An_StatePhys: str,
                     Fd_NDF: pd.Series, 
                     coeff_dict: dict
 ) -> pd.Series:
-    req_coeffs = ['En_CP', 'En_FA', 'En_rOM', 'En_St', 'En_NDF']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeffs)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {
+        'En_CP': 0.75, 'En_FA': 0.90, 'En_rOM': 0.80, 'En_St': 0.70, 'En_NDF': 0.65
+    }
+    Fd_Category = pd.Series(['Calf Liquid Feed', 'Adult Dry Feed'])
+    Fd_CP = pd.Series([20.0, 15.0])
+    Fd_FA = pd.Series([5.0, 6.0])
+    Fd_Ash = pd.Series([10.0, 8.0])
+    Fd_St = pd.Series([12.0, 14.0])
+    Fd_NDF = pd.Series([30.0, 25.0])
 
+    calculate_Fd_GE(
+        An_StatePhys = "Calf", 
+        Fd_Category = pd.Series(['Calf Liquid Feed', 'Adult Dry Feed']), 
+        Fd_CP = pd.Series([20.0, 15.0]), Fd_FA = pd.Series([5.0, 6.0]), 
+        Fd_Ash = pd.Series([10.0, 8.0]), Fd_St = pd.Series([12.0, 14.0]), 
+        Fd_NDF = pd.Series([30.0, 25.0]), coeff_dict = coeff_dict
+    )
+    ```
+    """
     condition = (An_StatePhys == "Calf") & (Fd_Category == "Calf Liquid Feed")
     Fd_GE = np.where(condition, 
                      (
@@ -271,8 +291,20 @@ def calculate_Fd_rdcRUPB(Fd_For: pd.Series,
                          Fd_KdRUP: pd.Series, 
                          coeff_dict: dict
 ) -> pd.Series:
-    req_coeffs = ['KpFor', 'KpConc']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeffs)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {
+        'KpFor': 4.87, 'KpConc': 5.28
+    }
+
+    calculate_Fd_rdcRUPB(
+        Fd_For = pd.Series([10.0, 15.0]), Fd_Conc = pd.Series([5.0, 7.0]), 
+        Fd_KdRUP = pd.Series([0.5, 0.6]), coeff_dict = coeff_dict
+    )
+    ```
+    """
     Fd_rdcRUPB = 100 - (
         Fd_For * coeff_dict['KpFor'] /
         (Fd_KdRUP + coeff_dict['KpFor']) + Fd_Conc * coeff_dict['KpConc'] /
@@ -286,8 +318,21 @@ def calculate_Fd_RUPBIn(Fd_For: pd.Series,
                         Fd_CPBIn: pd.Series, 
                         coeff_dict: dict
 ) -> pd.Series:
-    req_coeffs = ['KpFor', 'KpConc']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeffs)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {
+        'KpFor': 4.87, 'KpConc': 5.28
+    }
+
+    calculate_Fd_RUPBIn(
+        Fd_For = pd.Series([10.0, 15.0]), Fd_Conc = pd.Series([5.0, 7.0]),
+        Fd_KdRUP = pd.Series([0.5, 0.6]), Fd_CPBIn = pd.Series([12.0, 18.0]),
+        coeff_dict = coeff_dict
+    )
+    ```
+    """
     Fd_RUPBIn = (Fd_CPBIn * Fd_For / 
                  100 * coeff_dict['KpFor'] / 
                  (Fd_KdRUP + coeff_dict['KpFor']) + Fd_CPBIn * Fd_Conc / 
@@ -303,8 +348,21 @@ def calculate_Fd_RUPIn(Fd_CPIn: pd.Series,
                        Fd_RUPBIn: pd.Series,
                        coeff_dict: dict
 ) -> pd.Series:
-    req_coeffs = ['refCPIn', 'fCPAdu', 'IntRUP']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeffs)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {
+        'refCPIn': 3.39, 'fCPAdu': 0.064, 'IntRUP': -0.086
+    }
+
+    calculate_Fd_RUPIn(
+        Fd_CPIn = pd.Series([20.0, 25.0]), Fd_CPAIn = pd.Series([5.0, 6.0]), 
+        Fd_CPCIn = pd.Series([1.0, 1.5]), Fd_NPNCPIn = pd.Series([0.5, 0.7]), 
+        Fd_RUPBIn = pd.Series([10.0, 12.0]), coeff_dict = coeff_dict
+    )
+    ```
+    """
     Fd_RUPIn = ((Fd_CPAIn - Fd_NPNCPIn) * coeff_dict['fCPAdu'] + 
                 Fd_RUPBIn + Fd_CPCIn + coeff_dict['IntRUP'] / 
                 coeff_dict['refCPIn'] * Fd_CPIn) # Line 518
@@ -696,8 +754,19 @@ def calculate_Fd_DigStIn_Base(Fd_DigSt: pd.Series,
 
 
 def calculate_Fd_DigrOMt(Fd_rOM: pd.Series, coeff_dict: dict) -> pd.Series:
-    req_coeff = ['Fd_dcrOM']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {
+        'Fd_dcrOM': 96
+    }
+
+    calculate_Fd_DigrOMt(
+        Fd_rOM = pd.Series([100.0, 150.0]), coeff_dict = coeff_dict
+    )
+    ```
+    """
     # Truly digested rOM in each feed, % of DM
     Fd_DigrOMt = coeff_dict['Fd_dcrOM'] / 100 * Fd_rOM
     return Fd_DigrOMt
@@ -722,10 +791,23 @@ def calculate_TT_dcFdFA(An_StatePhys: str,
                         Fd_dcFA: pd.Series,
                         coeff_dict: dict
 ) -> pd.Series:
-    req_coeff = [
-        'TT_dcFA_Base', 'TT_dcFat_Base', 'TT_dcFA_ClfDryFd', 'TT_dcFA_ClfLiqFd'
-    ]
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {
+        'TT_dcFA_Base':73, 'TT_dcFat_Base': 68, 'TT_dcFA_ClfDryFd': 81, 
+        'TT_dcFA_ClfLiqFd': 81
+    }
+
+    calculate_TT_dcFdFA(
+        An_StatePhys = "Calf", Fd_dcFA = pd.Series([None, 0.70, None, None])
+        Fd_Category = pd.Series(["Fatty Acid Supplement", "Fat Supplement", "Calf Liquid Feed", "Other"])
+        Fd_Type = pd.Series(["Concentrate", "Other", "Concentrate", "Other"])
+        coeff_dict = coeff_dict
+    )
+    ```
+    """
     TT_dcFdFA = Fd_dcFA.copy()  # Line 1251
 
     condition_1 = (
@@ -772,9 +854,17 @@ def calculate_Fd_DigFAIn(TT_dcFdFA: pd.Series,
 def calculate_Fd_DigrOMa(Fd_DigrOMt: float, coeff_dict: dict) -> float:
     """
     Fd_DigrOMa: Apparently digested residual organic matter, % DM
+    
+    Examples
+    --------
+    ```
+    coeff_dict = {'Fe_rOMend_DMI': 3.43}
+
+    calculate_Fd_DigrOMa(
+        Fd_DigrOMt = 20.0, coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['Fe_rOMend_DMI']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     Fd_DigrOMa = Fd_DigrOMt - coeff_dict['Fe_rOMend_DMI']  # Line 1008
     # Apparently digested (% DM). Generates some negative values for minerals and other low rOM feeds.
     return Fd_DigrOMa
@@ -1162,37 +1252,84 @@ def calculate_Dt_dcCP_ClfDry(An_StatePhys: str, Dt_DMIn_ClfLiq: float) -> float:
 
 
 def calculate_Dt_DENDFIn(Dt_DigNDFIn: float, coeff_dict: dict) -> float:
-    req_coeff = ['En_NDF']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ``
+    coeff_dict = {'En_NDF': 4.2}
+
+    calculate_Dt_DENDFIn(
+        Dt_DigNDFIn = 10.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     Dt_DENDFIn = Dt_DigNDFIn * coeff_dict['En_NDF']
     return Dt_DENDFIn
 
 
 def calculate_Dt_DEStIn(Dt_DigStIn: float, coeff_dict: dict) -> float:
-    req_coeff = ['En_St']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {'En_St': 4.23}
+    
+    calculate_Dt_DEStIn(
+        Dt_DigStIn = 12.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     Dt_DEStIn = Dt_DigStIn * coeff_dict['En_St']
     return Dt_DEStIn
 
 
 def calculate_Dt_DErOMIn(Dt_DigrOMaIn: float, coeff_dict: dict) -> float:
-    req_coeff = ['En_rOM']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {'En_rOM': 4.0}
+    
+    calculate_Dt_DErOMIn(
+        Dt_DigrOMaIn = 12.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     Dt_DErOMIn = Dt_DigrOMaIn * coeff_dict['En_rOM']  # Line 1344
     return Dt_DErOMIn
 
 
 def calculate_Dt_DENPNCPIn(Dt_NPNCPIn: float, coeff_dict: dict) -> float:
-    req_coeff = ['En_NPNCP']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {
+        'dcNPNCP': 100, 'En_NPNCP': 0.89
+    }
+    
+    calculate_Dt_DENPNCPIn(
+        Dt_NPNCPIn = 15.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     Dt_DENPNCPIn = (Dt_NPNCPIn * coeff_dict['dcNPNCP'] / 
                     100 * coeff_dict['En_NPNCP'])
     return Dt_DENPNCPIn
 
 
 def calculate_Dt_DEFAIn(Dt_DigFAIn: float, coeff_dict: dict) -> float:
-    req_coeff = ['En_FA']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {'En_FA': 9.4}
+    
+    calculate_Dt_DEFAIn(
+        Dt_DigFAIn = 10.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     Dt_DEFAIn = Dt_DigFAIn * coeff_dict['En_FA']
     return Dt_DEFAIn
 
@@ -1209,8 +1346,19 @@ def calculate_Dt_DMIn_ClfStrt(An_BW: float,
                               Trg_Dt_DMIn: float, 
                               coeff_dict: dict
 ) -> float:
-    req_coeff = ['UCT']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {'UCT': 25.0}
+
+    calculate_Dt_DMIn_ClfStrt(
+        An_BW = 100.0, Dt_MEIn_ClfLiq = 15.0, Dt_DMIn_ClfLiq = 2.0, 
+        Dt_DMIn_ClfFor = 3.0, An_AgeDryFdStart = 30, Env_TempCurr = 28.0, 
+        DMIn_eqn = 1, Trg_Dt_DMIn = 10.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     # Predict Calf Starter Intake, kg/d
     # Temperate Environment Predicted Starter Intake, Line 301
     Dt_DMIn_ClfStrt = (-652.5 + 14.734 * An_BW + 
@@ -1240,8 +1388,17 @@ def calculate_Dt_DigCPaIn(Dt_CPIn: float, Fe_CP: float) -> float:
 
 
 def calculate_Dt_DECPIn(Dt_DigCPaIn: float, coeff_dict: dict) -> float:
-    req_coeff = ['En_CP']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {'En_CP': 5.65}
+
+    calculate_Dt_DECPIn(
+        Dt_DigCPaIn = 10.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     Dt_DECPIn = Dt_DigCPaIn * coeff_dict['En_CP']
     return Dt_DECPIn
 
@@ -1250,8 +1407,19 @@ def calculate_Dt_DETPIn(Dt_DECPIn: float,
                         Dt_DENPNCPIn: float, 
                         coeff_dict: dict
 ) -> float:
-    req_coeff = ['En_NPNCP', 'En_CP']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {
+        'En_NPNCP': 0.89, 'En_CP': 5.65
+    }
+
+    calculate_Dt_DETPIn(
+        Dt_DECPIn = 20.0, Dt_DENPNCPIn = 15.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     # Line 1348, Caution! DigTPaIn not clean so subtracted DE for CP equiv of 
     # NPN to correct. Not a true DE_TP.
     Dt_DETPIn = (Dt_DECPIn - Dt_DENPNCPIn / 
@@ -1336,9 +1504,17 @@ def calculate_Dt_DigrOMa_Dt(Dt_rOM: float, coeff_dict: dict) -> float:
     Dt_DigrOMa_Dt: Apparently digestable residual organic matter, % DM???
     
     This variable is not used anywhere, used as crosscheck? (see comment)
+    
+    Examples
+    --------
+    ```
+    coeff_dict = {'Fe_rOMend_DMI': 3.43}
+
+    calculate_Dt_DigrOMa_Dt(
+        Dt_rOM = 25.0, coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['Fe_rOMend_DMI']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     # In R code variable is Dt_DigrOMa.Dt
     Dt_DigrOMa_Dt = Dt_rOM * 0.96 - coeff_dict['Fe_rOMend_DMI']  
     # Crosscheck the feed level calculation and summation., Line 1041
@@ -1400,9 +1576,17 @@ def calculate_Dt_RDTPIn(Dt_RDPIn: float,
 ) -> float:
     """
     Dt_RDTPIn: Rumed degradable true protein intake, kg/d
+    
+    Examples
+    --------
+    ```
+    coeff_dict = {'dcNPNCP':100}
+
+    calculate_Dt_RDTPIn(
+        Dt_RDPIn = 10.0, Dt_NPNCPIn = 2.0, coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['dcNPNCP']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     Dt_RDTPIn = Dt_RDPIn - (Dt_NPNCPIn * coeff_dict['dcNPNCP'] / 100)  
     # assumes all NPN is soluble. Reflects only urea and ammonium salt
     # NPN sources, Line 1102
@@ -2270,12 +2454,6 @@ def calculate_diet_info(DMI: float,
         'Trp': SIDigTrpRUPf,
         'Val': SIDigValRUPf
     }
-
-    req_coeffs = [
-        'RecArg', 'RecHis', 'RecIle', 'RecLeu', 'RecLys', 'RecMet', 'RecPhe',
-        'RecThr', 'RecTrp', 'RecVal'
-    ]
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeffs)
 
     AA_list = [
         'Arg', 'His', 'Ile', 'Leu', 'Lys', 'Met', 'Phe', 'Thr', 'Trp', 'Val'

--- a/src/nasem_dairy/nasem_equations/nutrient_intakes.py
+++ b/src/nasem_dairy/nasem_equations/nutrient_intakes.py
@@ -6,7 +6,6 @@ import math
 import numpy as np
 import pandas as pd
 
-import nasem_dairy.model.utilities as ration_funcs
 
 ####################
 # Functions for Feed Intakes

--- a/src/nasem_dairy/nasem_equations/protein.py
+++ b/src/nasem_dairy/nasem_equations/protein.py
@@ -7,8 +7,17 @@ import nasem_dairy.model.utilities as ration_funcs
 
 
 def calculate_f_mPrt_max(An_305RHA_MlkTP: float, coeff_dict: dict) -> float:
-    req_coeffs = ['K_305RHA_MlkTP']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeffs)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {'K_305RHA_MlkTP': 1.0}
+
+    calculate_f_mPrt_max(
+        An_305RHA_MlkTP = 400.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     # Line 2116, 280kg RHA ~ 930 g mlk NP/d herd average
     f_mPrt_max = 1 + coeff_dict['K_305RHA_MlkTP'] * (An_305RHA_MlkTP / 280 - 1)
     return f_mPrt_max
@@ -20,8 +29,17 @@ def calculate_Du_MiCP_g(Du_MiN_g: float) -> float:
 
 
 def calculate_Du_MiTP_g(Du_MiCP_g: float, coeff_dict: dict) -> float:
-    req_coeffs = ['fMiTP_MiCP']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeffs)
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {'fMiTP_MiCP': 0.824}
+
+    calculate_Du_MiTP_g(
+        Du_MiCP_g = 100.0, coeff_dict = coeff_dict
+    )
+    ```
+    """
     Du_MiTP_g = coeff_dict['fMiTP_MiCP'] * Du_MiCP_g  # Line 1166
     return Du_MiTP_g
 
@@ -40,9 +58,17 @@ def calculate_Scrf_CP_g(An_StatePhys: str, An_BW: float) -> float:
 def calculate_Scrf_NP_g(Scrf_CP_g: float, coeff_dict: dict) -> float:
     """
     Scrf_NP_g: Scurf Net Protein, g
+    
+    Examples
+    --------
+    ```
+    coeff_dict = {'Body_NP_CP': 0.86}
+
+    calculate_Scrf_NP_g(
+        Scrf_CP_g = 150.0, coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['Body_NP_CP']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     Scrf_NP_g = Scrf_CP_g * coeff_dict['Body_NP_CP']  # Line 1966
     return Scrf_NP_g
 

--- a/src/nasem_dairy/nasem_equations/protein.py
+++ b/src/nasem_dairy/nasem_equations/protein.py
@@ -3,8 +3,6 @@
 import numpy as np
 import pandas as pd
 
-import nasem_dairy.model.utilities as ration_funcs
-
 
 def calculate_f_mPrt_max(An_305RHA_MlkTP: float, coeff_dict: dict) -> float:
     """

--- a/src/nasem_dairy/nasem_equations/protein_requirement.py
+++ b/src/nasem_dairy/nasem_equations/protein_requirement.py
@@ -24,8 +24,6 @@ def calculate_Body_MPUse_g_Trg_initial(Body_NPgain_g: float,
     """
     Body_MPUse_g_Trg: Metabolizable protein requirement for reserve and frame gain (g/d)
     """
-    # req_coeff = ['Kg_MP_NP_Trg']
-    # ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     Body_MPUse_g_Trg = Body_NPgain_g / Kg_MP_NP_Trg  
     # Line 2675, kg MP/d for NP gain
     return Body_MPUse_g_Trg
@@ -34,9 +32,19 @@ def calculate_Body_MPUse_g_Trg_initial(Body_NPgain_g: float,
 def calculate_Gest_MPUse_g_Trg(Gest_NPuse_g: float, coeff_dict: dict) -> float:
     """
     Gest_MPUse_g_Trg: Metabolizable protein requirement for gestation (g/d)
+
+    Examples
+    --------
+    ```
+    coeff_dict = {
+        'Ky_MP_NP_Trg': 0.33, 'Ky_NP_MP_Trg': 1.0
+    }
+
+    calculate_Gest_MPUse_g_Trg(
+        Gest_NPuse_g = 100.0, coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['Ky_MP_NP_Trg', 'Ky_NP_MP_Trg']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     if Gest_NPuse_g >= 0:  # Line 2676
         Gest_MPUse_g_Trg = Gest_NPuse_g / coeff_dict['Ky_MP_NP_Trg']
     else:
@@ -55,9 +63,17 @@ def calculate_Trg_Mlk_NP_g(Trg_MilkProd: float, Trg_MilkTPp: float) -> float:
 def calculate_Mlk_MPUse_g_Trg(Trg_Mlk_NP_g: float, coeff_dict: dict) -> float:
     """
     Mlk_MPUse_g_Trg: Metabolizable protein requirement for milk production (g/d)
+    
+    Examples
+    --------
+    ```
+    coeff_dict = {'Kl_MP_NP_Trg': 0.69}
+
+    calculate_Mlk_MPUse_g_Trg(
+        Trg_Mlk_NP_g = 150.0, coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['Kl_MP_NP_Trg']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     Mlk_MPUse_g_Trg = Trg_Mlk_NP_g / coeff_dict['Kl_MP_NP_Trg']  
     # kg MP/d for target milk protein lactation, Line 2677
     return Mlk_MPUse_g_Trg
@@ -139,9 +155,24 @@ def calculate_Kg_MP_NP_Trg(An_StatePhys: str,
 ) -> float:
     """
     Kg_MP_NP_Trg: Conversion of NP to MP for growth
+    
+    Examples
+    --------
+    ```
+    coeff_dict = {
+        'Body_NP_CP': 0.86
+    }
+    MP_NP_efficiency_dict = {
+        'Trg_MP_NP': 0.69
+    }
+
+    calculate_Kg_MP_NP_Trg(
+        An_StatePhys = "Calf", An_Parity_rl = 0, An_BW = 150.0, 
+        An_BW_empty = 40.0, An_BW_mature = 600.0, An_BWmature_empty = 70.0, 
+        MP_NP_efficiency_dict = MP_NP_efficiency_dict, coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['Body_NP_CP']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     # Default value for Growth MP to TP.  Shouldn't be used for any., Line 2659
     Kg_MP_NP_Trg = 0.60 * coeff_dict['Body_NP_CP']  
 
@@ -243,9 +274,19 @@ def calculate_Trg_MPIn_req(Fe_MPendUse_g_Trg: float,
 ) -> float:
     """
     Trg_MPIn_req: Target MP requirement (g/d)
+
+    Examples
+    --------
+    ```
+    coeff_dict = {'Kl_MP_NP_Trg': 0.69}
+
+    calculate_Trg_MPIn_req(
+        Fe_MPendUse_g_Trg = 50.0, Scrf_MPUse_g_Trg = 30.0, Ur_MPendUse_g = 20.0, 
+        Body_MPUse_g_Trg = 15.0, Gest_MPUse_g_Trg = 40.0, Trg_Mlk_NP_g = 200.0, 
+        coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['Kl_MP_NP_Trg']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     Trg_MPIn_req = (Fe_MPendUse_g_Trg + Scrf_MPUse_g_Trg + Ur_MPendUse_g + 
                     Body_MPUse_g_Trg + Gest_MPUse_g_Trg + Trg_Mlk_NP_g / 
                     coeff_dict['Kl_MP_NP_Trg'])  # Line 2710
@@ -253,10 +294,19 @@ def calculate_Trg_MPIn_req(Fe_MPendUse_g_Trg: float,
 
 
 def calculate_Km_MP_NP_Trg(An_StatePhys: str, coeff_dict: dict) -> float:
+    """
+    Examples
+    --------
+    ```
+    coeff_dict = {'Kx_MP_NP_Trg': 0.69}
+
+    calculate_Km_MP_NP_Trg(
+        An_StatePhys = "Cow", coeff_dict = coeff_dict
+    )
+    ```
+    """
     # Maintenance assumed to be equal to target efficiency for export plus 
     # gain protein
-    req_coeff = ['Kx_MP_NP_Trg']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     if An_StatePhys in ["Calf", "Heifer"]:
         Km_MP_NP_Trg = 0.66
     else:

--- a/src/nasem_dairy/nasem_equations/protein_requirement.py
+++ b/src/nasem_dairy/nasem_equations/protein_requirement.py
@@ -3,8 +3,6 @@
 
 import numpy as np
 
-import nasem_dairy.model.utilities as ration_funcs
-
 
 def calculate_An_MPm_g_Trg(Fe_MPendUse_g_Trg: float, 
                            Scrf_MPuse_g_Trg: float,

--- a/src/nasem_dairy/nasem_equations/urine.py
+++ b/src/nasem_dairy/nasem_equations/urine.py
@@ -100,9 +100,17 @@ def calculate_Ur_NPend_3MH_g(An_BW: float) -> float:
 def calculate_Ur_Nend_3MH_g(Ur_NPend_3MH_g: float, coeff_dict: dict) -> float:
     """
     Ur_Nend_3MH_g: endogenous 3-methyl-histidine N (g/d)
+    
+    Examples
+    --------
+    ```
+    coeff_dict = {'fN_3MH': 0.249}
+
+    calculate_Ur_Nend_3MH_g(
+        Ur_NPend_3MH_g = 200.0, coeff_dict = coeff_dict
+    )
+    ```
     """
-    req_coeff = ['fN_3MH']
-    ration_funcs.check_coeffs_in_coeff_dict(coeff_dict, req_coeff)
     Ur_Nend_3MH_g = Ur_NPend_3MH_g * coeff_dict['fN_3MH']  # Line 2024
     return Ur_Nend_3MH_g
 

--- a/src/nasem_dairy/nasem_equations/urine.py
+++ b/src/nasem_dairy/nasem_equations/urine.py
@@ -3,8 +3,6 @@
 import numpy as np
 import pandas as pd
 
-import nasem_dairy.model.utilities as ration_funcs
-
 
 def calculate_Ur_Nout_g(Dt_CPIn: float, 
                         Fe_CP: float, 


### PR DESCRIPTION
_Fill in information for PR below. On review, add additional commits and a comment thats checks off any tasks so that all are complete before merging._

### Description of changes
Removed the check_coeffs_in_coeff_dict function from the package. The input validation module will catch any issues with coeff_dict. Checking coefficients within each function is no longer necessary. 

### Issue number/s 
fixes #103

### Checklist of all completed
Mark with `[x]` to show completed:  

- [x] No merge conflicts (if conflicts, merge main to branch and resolve before making PR)
- [x] Tests written (if feature added or refactored)
- [x] pytest passing
- [x] Docstrings - minor
- [ ] Full documentation