### PR TITLE
fix(validate_coeff_dict):

### DIFF
--- a/src/nasem_dairy/model/input_validation.py
+++ b/src/nasem_dairy/model/input_validation.py
@@ -201,8 +201,6 @@ def validate_coeff_dict(coeff_dict: dict) -> dict:
         for key in differing_keys:
             print(f"{key}: User: {corrected_dict[key]}, "
                   f"Default: {default_coeff_dict[key]}")
-    else:
-        print("All values match the default coefficients.")
     return corrected_dict
 
 

--- a/tests/input_validation/test_validate_coeff_dict.py
+++ b/tests/input_validation/test_validate_coeff_dict.py
@@ -38,8 +38,7 @@ def test_differing_values(capfd):
     assert "VmMiNInt: User: 101.0, Default: 100.8" in out
 
 
-def test_all_values_match(capfd):
+def test_all_values_match():
     user_coeff_dict = nd.coeff_dict.copy()   
-    validate_coeff_dict(user_coeff_dict)
-    out, err = capfd.readouterr()
-    assert "All values match the default coefficients." in out
+    corrected_coeff_dict = validate_coeff_dict(user_coeff_dict)
+    assert corrected_coeff_dict == user_coeff_dict


### PR DESCRIPTION
function no longer prints message when no issues are found in coeff_dict

_Fill in information for PR below. On review, add additional commits and a comment thats checks off any tasks so that all are complete before merging._

### Description of changes
Remove print statement from validate_coeff_dict. No message is printed when no issues are found in coeff_dict. Updated validate_coeff_dict tests

### Issue number/s 
fixes #134

### Checklist of all completed
Mark with `[x]` to show completed:  

- [x] No merge conflicts (if conflicts, merge main to branch and resolve before making PR)
- [x] Tests written (if feature added or refactored)
- [x] pytest passing
- [ ] Docstrings - minor
- [ ] Full documentation