### PR TITLE
Fix: apply the 10 g/d floor to Du_MiCP_g (R line 1165)

### DIFF
--- a/src/nasem_dairy/nasem_equations/protein.py
+++ b/src/nasem_dairy/nasem_equations/protein.py
@@ -27,6 +27,8 @@ def calculate_f_mPrt_max(An_305RHA_MlkTP: float, coeff_dict: dict) -> float:
 
 def calculate_Du_MiCP_g(Du_MiN_g: float) -> float:
     Du_MiCP_g = Du_MiN_g * 6.25  # Line 1163
+    # Truncate to 10 to prevent negative values
+    Du_MiCP_g = np.maximum(Du_MiCP_g, 10)  # Line 1165
     return Du_MiCP_g
 
 

--- a/tests/nasem_unit_testing/protein_equations_test.json
+++ b/tests/nasem_unit_testing/protein_equations_test.json
@@ -1,222 +1,420 @@
 [
     {
-      "Name": "calculate_f_mPrt_max",
-      "Input": { "An_305RHA_MlkTP": 240, "coeff_dict": null },
-      "Output": 0.8571428571428571
+        "Name": "calculate_f_mPrt_max",
+        "Input": {
+            "An_305RHA_MlkTP": 240,
+            "coeff_dict": null
+        },
+        "Output": 0.8571428571428571
     },
     {
-      "Name": "calculate_Du_MiCP_g",
-      "Input": { "Du_MiN_g": 112 },
-      "Output": 700
+        "Name": "calculate_Du_MiCP_g",
+        "Input": {
+            "Du_MiN_g": 112
+        },
+        "Output": 700
     },
     {
-      "Name": "calculate_Du_MiTP_g",
-      "Input": { "Du_MiCP_g": 648, "coeff_dict": null },
-      "Output": 533.952
+        "Name": "calculate_Du_MiCP_g",
+        "Input": {
+            "Du_MiN_g": 1.0
+        },
+        "Output": 10
     },
     {
-      "Name": "calculate_Scrf_CP_g",
-      "Input": {"An_BW": 782, "An_StatePhys": "Lactating Cow"},
-      "Output": 10.8881488
+        "Name": "calculate_Du_MiTP_g",
+        "Input": {
+            "Du_MiCP_g": 648,
+            "coeff_dict": null
+        },
+        "Output": 533.952
     },
     {
         "Name": "calculate_Scrf_CP_g",
-        "Input": {"An_BW": 58, "An_StatePhys": "Calf"},
+        "Input": {
+            "An_BW": 782,
+            "An_StatePhys": "Lactating Cow"
+        },
+        "Output": 10.8881488
+    },
+    {
+        "Name": "calculate_Scrf_CP_g",
+        "Input": {
+            "An_BW": 58,
+            "An_StatePhys": "Calf"
+        },
         "Output": 2.5032309
     },
     {
-      "Name": "calculate_Scrf_CP_g",
-      "Input": {"An_StatePhys": "Calf", "An_BW": 84},
-      "Output": 3.126163488
+        "Name": "calculate_Scrf_CP_g",
+        "Input": {
+            "An_StatePhys": "Calf",
+            "An_BW": 84
+        },
+        "Output": 3.126163488
     },
     {
-      "Name": "calculate_Scrf_CP_g",
-      "Input": {"An_StatePhys": "Heifer", "An_BW": 624},
-      "Output": 9.509129228475745
+        "Name": "calculate_Scrf_CP_g",
+        "Input": {
+            "An_StatePhys": "Heifer",
+            "An_BW": 624
+        },
+        "Output": 9.509129228475745
     },
     {
-      "Name": "calculate_Scrf_NP_g",
-      "Input": {"Scrf_CP_g": 7, "coeff_dict": null},
-      "Output": 6.02
+        "Name": "calculate_Scrf_NP_g",
+        "Input": {
+            "Scrf_CP_g": 7,
+            "coeff_dict": null
+        },
+        "Output": 6.02
     },
     {
-      "Name": "calculate_Scrf_MPUse_g_Trg",
-      "Input": {"An_StatePhys": "Calf", "Scrf_CP_g": 4.9, "Scrf_NP_g": 3.4, "Km_MP_NP_Trg": 0.66},
-      "Output": 7.424242424242425
+        "Name": "calculate_Scrf_MPUse_g_Trg",
+        "Input": {
+            "An_StatePhys": "Calf",
+            "Scrf_CP_g": 4.9,
+            "Scrf_NP_g": 3.4,
+            "Km_MP_NP_Trg": 0.66
+        },
+        "Output": 7.424242424242425
     },
     {
-      "Name": "calculate_Scrf_MPUse_g_Trg",
-      "Input": {"An_StatePhys": "Heifer", "Scrf_CP_g": 8.1, "Scrf_NP_g": 5.1, "Km_MP_NP_Trg": 0.66},
-      "Output": 12.272727272727272
+        "Name": "calculate_Scrf_MPUse_g_Trg",
+        "Input": {
+            "An_StatePhys": "Heifer",
+            "Scrf_CP_g": 8.1,
+            "Scrf_NP_g": 5.1,
+            "Km_MP_NP_Trg": 0.66
+        },
+        "Output": 12.272727272727272
     },
     {
-      "Name": "calculate_Scrf_MPUse_g_Trg",
-      "Input": {"An_StatePhys": "Lactating Cow", "Scrf_CP_g": 5.1, "Scrf_NP_g": 8.9, "Km_MP_NP_Trg": 0.66},
-      "Output": 13.484848484848484
+        "Name": "calculate_Scrf_MPUse_g_Trg",
+        "Input": {
+            "An_StatePhys": "Lactating Cow",
+            "Scrf_CP_g": 5.1,
+            "Scrf_NP_g": 8.9,
+            "Km_MP_NP_Trg": 0.66
+        },
+        "Output": 13.484848484848484
     },
     {
-      "Name": "calculate_Scrf_NP",
-      "Input": {"Scrf_NP_g": 1509},
-      "Output": 1.5090000000000001
+        "Name": "calculate_Scrf_NP",
+        "Input": {
+            "Scrf_NP_g": 1509
+        },
+        "Output": 1.5090000000000001
     },
     {
-      "Name": "calculate_Scrf_N_g",
-      "Input": {"Scrf_CP_g": 4820},
-      "Output": 771.2
+        "Name": "calculate_Scrf_N_g",
+        "Input": {
+            "Scrf_CP_g": 4820
+        },
+        "Output": 771.2
     },
     {
-      "Name": "calculate_ScrfAA_AbsAA",
-      "Input": {"Scrf_AA_g": 1043, "Abs_AA_g": 2303},
-      "Output": 0.45288753799392095
+        "Name": "calculate_ScrfAA_AbsAA",
+        "Input": {
+            "Scrf_AA_g": 1043,
+            "Abs_AA_g": 2303
+        },
+        "Output": 0.45288753799392095
     },
     {
-      "Name": "calculate_An_CPxprt_g",
-      "Input": {"Scrf_CP_g": 2.5, "Fe_CPend_g": 1.1, "Mlk_CP_g": 3.6, "Body_CPgain_g": 0.6},
-      "Output": 7.8
+        "Name": "calculate_An_CPxprt_g",
+        "Input": {
+            "Scrf_CP_g": 2.5,
+            "Fe_CPend_g": 1.1,
+            "Mlk_CP_g": 3.6,
+            "Body_CPgain_g": 0.6
+        },
+        "Output": 7.8
     },
     {
-      "Name": "calculate_An_NPxprt_g",
-      "Input": {"Scrf_NP_g": 4.1, "Fe_NPend_g": 5, "Mlk_NP_g": 3.9, "Body_NPgain_g": 8.2},
-      "Output": 21.2
+        "Name": "calculate_An_NPxprt_g",
+        "Input": {
+            "Scrf_NP_g": 4.1,
+            "Fe_NPend_g": 5,
+            "Mlk_NP_g": 3.9,
+            "Body_NPgain_g": 8.2
+        },
+        "Output": 21.2
     },
     {
-      "Name": "calculate_Trg_NPxprt_g",
-      "Input": {"Scrf_NP_g": 6.4, "Fe_NPend_g": 8.1, "Trg_Mlk_NP_g": 1.9, "Body_NPgain_g": 2.7},
-      "Output": 19.099999999999998
+        "Name": "calculate_Trg_NPxprt_g",
+        "Input": {
+            "Scrf_NP_g": 6.4,
+            "Fe_NPend_g": 8.1,
+            "Trg_Mlk_NP_g": 1.9,
+            "Body_NPgain_g": 2.7
+        },
+        "Output": 19.099999999999998
     },
     {
-      "Name": "calculate_An_CPprod_g",
-      "Input": {"Mlk_CP_g": 1294, "Gest_NCPgain_g": 2540, "Body_CPgain_g": 210},
-      "Output": 4044
+        "Name": "calculate_An_CPprod_g",
+        "Input": {
+            "Mlk_CP_g": 1294,
+            "Gest_NCPgain_g": 2540,
+            "Body_CPgain_g": 210
+        },
+        "Output": 4044
     },
     {
-      "Name": "calculate_An_NPprod_g",
-      "Input": {"Mlk_NP_g": 1284, "Gest_NPgain_g": 391, "Body_NPgain_g": 1290},
-      "Output": 2965
+        "Name": "calculate_An_NPprod_g",
+        "Input": {
+            "Mlk_NP_g": 1284,
+            "Gest_NPgain_g": 391,
+            "Body_NPgain_g": 1290
+        },
+        "Output": 2965
     },
     {
-      "Name": "calculate_Trg_NPprod_g",
-      "Input": {"Trg_Mlk_NP_g": 1940, "Gest_NPgain_g": 201, "Body_NPgain_g": 301},
-      "Output": 2442
+        "Name": "calculate_Trg_NPprod_g",
+        "Input": {
+            "Trg_Mlk_NP_g": 1940,
+            "Gest_NPgain_g": 201,
+            "Body_NPgain_g": 301
+        },
+        "Output": 2442
     },
     {
-      "Name": "calculate_An_NPprod_MPIn",
-      "Input": {"An_NPprod_g": 1202, "An_MPIn_g": 4120},
-      "Output": 0.291747572815534
+        "Name": "calculate_An_NPprod_MPIn",
+        "Input": {
+            "An_NPprod_g": 1202,
+            "An_MPIn_g": 4120
+        },
+        "Output": 0.291747572815534
     },
     {
-      "Name": "calculate_Trg_NPuse_g",
-      "Input": {"Scrf_NP_g": 2933, "Fe_NPend_g": 1290, "Ur_NPend_g": 219, "Trg_Mlk_NP_g": 4712, "Body_NPgain_g": 2183, "Gest_NPgain_g": 810},
-      "Output": 12147
+        "Name": "calculate_Trg_NPuse_g",
+        "Input": {
+            "Scrf_NP_g": 2933,
+            "Fe_NPend_g": 1290,
+            "Ur_NPend_g": 219,
+            "Trg_Mlk_NP_g": 4712,
+            "Body_NPgain_g": 2183,
+            "Gest_NPgain_g": 810
+        },
+        "Output": 12147
     },
     {
-      "Name": "calculate_An_NPuse_g",
-      "Input": {"Scrf_NP_g": 129, "Fe_NPend_g": 313, "Ur_NPend_g": 453, "Mlk_NP_g": 3102, "Body_NPgain_g": 612, "Gest_NPgain_g": 129},
-      "Output": 4738
+        "Name": "calculate_An_NPuse_g",
+        "Input": {
+            "Scrf_NP_g": 129,
+            "Fe_NPend_g": 313,
+            "Ur_NPend_g": 453,
+            "Mlk_NP_g": 3102,
+            "Body_NPgain_g": 612,
+            "Gest_NPgain_g": 129
+        },
+        "Output": 4738
     },
     {
-      "Name": "calculate_An_NCPuse_g",
-      "Input": {"Scrf_CP_g": 912, "Fe_CPend_g": 239, "Ur_NPend_g": 401, "Mlk_CP_g": 301, "Body_CPgain_g": 712, "Gest_NCPgain_g": 323},
-      "Output": 2888
+        "Name": "calculate_An_NCPuse_g",
+        "Input": {
+            "Scrf_CP_g": 912,
+            "Fe_CPend_g": 239,
+            "Ur_NPend_g": 401,
+            "Mlk_CP_g": 301,
+            "Body_CPgain_g": 712,
+            "Gest_NCPgain_g": 323
+        },
+        "Output": 2888
     },
     {
-      "Name": "calculate_An_Nprod_g",
-      "Input": {"Gest_NCPgain_g": 123, "Body_CPgain_g": 3203, "Mlk_CP_g": 303},
-      "Output": 579.9517981072555
+        "Name": "calculate_An_Nprod_g",
+        "Input": {
+            "Gest_NCPgain_g": 123,
+            "Body_CPgain_g": 3203,
+            "Mlk_CP_g": 303
+        },
+        "Output": 579.9517981072555
     },
     {
-      "Name": "calculate_An_Nprod_NIn",
-      "Input": {"An_Nprod_g": 313, "An_NIn_g": 1291},
-      "Output": 0.24244771494965142
+        "Name": "calculate_An_Nprod_NIn",
+        "Input": {
+            "An_Nprod_g": 313,
+            "An_NIn_g": 1291
+        },
+        "Output": 0.24244771494965142
     },
     {
-      "Name": "calculate_An_Nprod_DigNIn",
-      "Input": {"An_Nprod_g": 1012, "An_DigNtIn_g": 2013},
-      "Output": 0.5027322404371585
+        "Name": "calculate_An_Nprod_DigNIn",
+        "Input": {
+            "An_Nprod_g": 1012,
+            "An_DigNtIn_g": 2013
+        },
+        "Output": 0.5027322404371585
     },
     {
-      "Name": "calculate_An_MPBal_g_Trg",
-      "Input": {"An_MPIn_g": 4030, "An_MPuse_g_Trg": 3821},
-      "Output": 209
+        "Name": "calculate_An_MPBal_g_Trg",
+        "Input": {
+            "An_MPIn_g": 4030,
+            "An_MPuse_g_Trg": 3821
+        },
+        "Output": 209
     },
     {
-      "Name": "calculate_Xprt_NP_MP_Trg",
-      "Input": {"Scrf_NP_g": 129, "Fe_NPend_g": 605, "Trg_Mlk_NP_g": 3301, "Body_NPgain_g": 312, "An_MPIn_g": 5012, "Ur_NPend_g": 321, "Gest_MPUse_g_Trg": 130},
-      "Output": 0.9530804648103486
+        "Name": "calculate_Xprt_NP_MP_Trg",
+        "Input": {
+            "Scrf_NP_g": 129,
+            "Fe_NPend_g": 605,
+            "Trg_Mlk_NP_g": 3301,
+            "Body_NPgain_g": 312,
+            "An_MPIn_g": 5012,
+            "Ur_NPend_g": 321,
+            "Gest_MPUse_g_Trg": 130
+        },
+        "Output": 0.9530804648103486
     },
     {
-      "Name": "calculate_Xprt_NP_MP",
-      "Input": {"Scrf_NP_g": 302, "Fe_NPend_g": 1201, "Mlk_NP_g": 4501, "Body_NPgain_g": 103, "An_MPIn_g": 419, "Ur_NPend_g": 846, "Gest_MPUse_g_Trg": 330},
-      "Output": -8.067371202113605
+        "Name": "calculate_Xprt_NP_MP",
+        "Input": {
+            "Scrf_NP_g": 302,
+            "Fe_NPend_g": 1201,
+            "Mlk_NP_g": 4501,
+            "Body_NPgain_g": 103,
+            "An_MPIn_g": 419,
+            "Ur_NPend_g": 846,
+            "Gest_MPUse_g_Trg": 330
+        },
+        "Output": -8.067371202113605
     },
     {
-      "Name": "calculate_Km_MP_NP",
-      "Input": {"An_StatePhys": "Heifer", "Xprt_NP_MP": 0.754},
-      "Output": 0.69
+        "Name": "calculate_Km_MP_NP",
+        "Input": {
+            "An_StatePhys": "Heifer",
+            "Xprt_NP_MP": 0.754
+        },
+        "Output": 0.69
     },
     {
-      "Name": "calculate_Km_MP_NP",
-      "Input": {"An_StatePhys": "Lactating Cow", "Xprt_NP_MP": 0.754},
-      "Output": 0.754
+        "Name": "calculate_Km_MP_NP",
+        "Input": {
+            "An_StatePhys": "Lactating Cow",
+            "Xprt_NP_MP": 0.754
+        },
+        "Output": 0.754
     },
     {
-      "Name": "calculate_Kl_MP_NP",
-      "Input": {"Xprt_NP_MP": 0.48},
-      "Output": 0.48
+        "Name": "calculate_Kl_MP_NP",
+        "Input": {
+            "Xprt_NP_MP": 0.48
+        },
+        "Output": 0.48
     },
     {
-      "Name": "calculate_Scrf_MPUse_g",
-      "Input": {"Scrf_NP_g": 1301, "Km_MP_NP": 0.83},
-      "Output": 1567.4698795180723
+        "Name": "calculate_Scrf_MPUse_g",
+        "Input": {
+            "Scrf_NP_g": 1301,
+            "Km_MP_NP": 0.83
+        },
+        "Output": 1567.4698795180723
     },
     {
-      "Name": "calculate_An_MPuse_g",
-      "Input": {"Fe_MPendUse_g": 310, "Scrf_MPUse_g": 741, "Ur_MPendUse_g": 810, "Body_MPUse_g_Trg": 104, "Gest_MPUse_g_Trg": 91, "Mlk_MPUse_g": 3012},
-      "Output": 5068
+        "Name": "calculate_An_MPuse_g",
+        "Input": {
+            "Fe_MPendUse_g": 310,
+            "Scrf_MPUse_g": 741,
+            "Ur_MPendUse_g": 810,
+            "Body_MPUse_g_Trg": 104,
+            "Gest_MPUse_g_Trg": 91,
+            "Mlk_MPUse_g": 3012
+        },
+        "Output": 5068
     },
     {
-      "Name": "calculate_An_MPuse",
-      "Input": {"An_MPuse_g": 2693},
-      "Output": 2.693
+        "Name": "calculate_An_MPuse",
+        "Input": {
+            "An_MPuse_g": 2693
+        },
+        "Output": 2.693
     },
     {
-      "Name": "calculate_An_MPBal_g",
-      "Input": {"An_MPIn_g": 4019, "An_MPuse_g": 2034},
-      "Output": 1985
+        "Name": "calculate_An_MPBal_g",
+        "Input": {
+            "An_MPIn_g": 4019,
+            "An_MPuse_g": 2034
+        },
+        "Output": 1985
     },
     {
-      "Name": "calculate_An_MP_NP",
-      "Input": {"An_NPuse_g": 1291, "An_MPuse_g": 3012},
-      "Output": 0.42861885790172644
+        "Name": "calculate_An_MP_NP",
+        "Input": {
+            "An_NPuse_g": 1291,
+            "An_MPuse_g": 3012
+        },
+        "Output": 0.42861885790172644
     },
     {
-      "Name": "calculate_An_NPxprt_MP",
-      "Input": {"An_NPuse_g": 1202, "Ur_NPend_g": 8412, "Gest_NPuse_g": 239, "An_MPIn_g": 301, "Gest_MPUse_g_Trg": 471},
-      "Output": 0.8679794919599161
+        "Name": "calculate_An_NPxprt_MP",
+        "Input": {
+            "An_NPuse_g": 1202,
+            "Ur_NPend_g": 8412,
+            "Gest_NPuse_g": 239,
+            "An_MPIn_g": 301,
+            "Gest_MPUse_g_Trg": 471
+        },
+        "Output": 0.8679794919599161
     },
     {
-      "Name": "calculate_An_CP_NP",
-      "Input": {"An_NPuse_g": 1410, "An_CPIn": 7.4},
-      "Output": 0.19054054054054054
+        "Name": "calculate_An_CP_NP",
+        "Input": {
+            "An_NPuse_g": 1410,
+            "An_CPIn": 7.4
+        },
+        "Output": 0.19054054054054054
     },
     {
-      "Name": "calculate_An_NPBal_g",
-      "Input": {"An_MPIn_g": 4301, "An_MP_NP": 0.74, "An_NPuse_g": 1301},
-      "Output": 1881.7399999999998
+        "Name": "calculate_An_NPBal_g",
+        "Input": {
+            "An_MPIn_g": 4301,
+            "An_MP_NP": 0.74,
+            "An_NPuse_g": 1301
+        },
+        "Output": 1881.7399999999998
     },
     {
-      "Name": "calculate_An_NPBal",
-      "Input": {"An_NPBal_g": 3013},
-      "Output": 3.013
+        "Name": "calculate_An_NPBal",
+        "Input": {
+            "An_NPBal_g": 3013
+        },
+        "Output": 3.013
     },
     {
-      "Name": "calculate_Scrf_AA_TP",
-      "Input": { "aa_list": null, "coeff_dict": null},
-      "Output": [9.6, 1.75, 2.96, 6.93, 5.64, 1.4, 3.61, 4.01, 0.73, 4.66]
+        "Name": "calculate_Scrf_AA_TP",
+        "Input": {
+            "aa_list": null,
+            "coeff_dict": null
+        },
+        "Output": [
+            9.6,
+            1.75,
+            2.96,
+            6.93,
+            5.64,
+            1.4,
+            3.61,
+            4.01,
+            0.73,
+            4.66
+        ]
     },
     {
-      "Name": "calculate_Scrf_AA_g",
-      "Input": { "Scrf_NP_g": 543, "Scrf_AA_TP_series": [3.4, 5.8, 12.2]},
-      "Output": [18.462, 31.494, 66.246]
+        "Name": "calculate_Scrf_AA_g",
+        "Input": {
+            "Scrf_NP_g": 543,
+            "Scrf_AA_TP_series": [
+                3.4,
+                5.8,
+                12.2
+            ]
+        },
+        "Output": [
+            18.462,
+            31.494,
+            66.246
+        ]
     }
-  ]
+]


### PR DESCRIPTION
## Summary

`calculate_Du_MiCP_g` ports line 1163 of the reference R script (`Du_MiCP_g <- Du_MiN_g * 6.25`) but omits line 1165:

```r
Du_MiCP_g <- ifelse(Du_MiCP_g<10, 10, Du_MiCP_g)	#Truncate to 10 to prevent negative values
```

(both lines are in `original_R_script/NRC Dairy 2020 Model Fn - 2022_09_02.R`, which this repo bundles).

This PR adds the floor with `np.maximum(Du_MiCP_g, 10)` and a JSON unit-test case that exercises it (`Du_MiN_g = 1.0` → expected `10`, not `6.25`).

## When it matters

The floor only binds when raw microbial CP is below 10 g/d — in practice, milk-fed calves with low starter intake. The bundled `young_calf` integration fixture (DMI 6.5 kg) never reaches that region, which is why the existing suite doesn't catch the omission.

We found this by independently cross-validating `nasem_dairy` 1.0.2 against a licensed copy of the official R model (`NRC2020()`, build 2022_09_02) on the 13 official NASEM example simulations, diffing ~611–617 scalar outputs per scenario at 1e-3 tolerance:

- 7 lactating scenarios: **all scalars match** (613/613) — no change needed.
- Heifer/dry-cow scenarios: only inf-vs-NaN division conventions in milk ratios — no change needed.
- Calf scenarios: ~30 divergent N/protein/energy variables, **all downstream of this single missing floor**. With this one-line fix they collapse to the same non-substantive convention differences as the other scenarios (575/607 → 606/611 matching).

## Test plan

- `pytest`: 134 passed, 19 skipped (full suite from the repo root, including the new floor case).